### PR TITLE
 test(mocha): test filesRequire functionality 

### DIFF
--- a/src/mocha/mocha.ts
+++ b/src/mocha/mocha.ts
@@ -16,18 +16,16 @@ export function CreateMochaTester(): TesterExtension {
             }
         },
         getDynamicConfig: function (info: ActionTesterOptions) {
-            // console.log('getDynamicConfig')
             let config = mochaFindConfiguration(info)
-            return config.save ? config.config : {}
+            return config.save ? config.config : info.rawConfig
         },
         action: function (info: ActionTesterOptions) {
-            // console.log('action')
             const correctFolder = info.context.componentDir || info.context.workspaceDir
             const privateRequire = createPrivateRequire(correctFolder)
-            _get(info, 'context.componentObject.dynamicConfig.require', []).forEach(function(toRequire:string){
+            _get(info, 'dynamicConfig.require', []).forEach(function(toRequire:string){
                 privateRequire(toRequire)
             })
-            _get(info, 'context.componentObject.dynamicConfig.filesRequire', []).forEach(function(toRequire:string){
+            _get(info, 'dynamicConfig.filesRequire', []).forEach(function(toRequire:string){
                 require(path.resolve(correctFolder, toRequire))
             })
             cleanPrivateRequire(correctFolder)

--- a/test/mocha/fixture/test.spec.js
+++ b/test/mocha/fixture/test.spec.js
@@ -5,4 +5,7 @@ describe('basic', function (){
     it('should add properly', function() {
         expect(run()).to.equal(0)
     })
+    it('should preload a file specified with `filesRequire` in the config', function() {
+        expect(global.mochaSetupTestRun).to.equal(true)
+    })
 })

--- a/test/mocha/fixture/test.spec.js
+++ b/test/mocha/fixture/test.spec.js
@@ -6,6 +6,6 @@ describe('basic', function (){
         expect(run()).to.equal(0)
     })
     it('should preload a file specified with `filesRequire` in the config', function() {
-        expect(global.mochaSetupTestRun).to.equal(true)
+        expect(global.mochaSetupTestRun).to.be.true
     })
 })

--- a/test/mocha/mocha.spec.ts
+++ b/test/mocha/mocha.spec.ts
@@ -49,14 +49,14 @@ describe('mocha', function () {
         const actionInfo = {
             testFiles,
             configFiles: [],
+            dynamicConfig: {
+                'require': ['babel-core/register', 'source-map-support/register'],
+                'filesRequire': ['setup.js']
+            },
             context: {
                 componentDir: baseFixturePath,
                 componentObject: {
-                    mainFile: '',
-                    dynamicConfig: {
-                        'require': ['babel-core/register', 'source-map-support/register'],
-                        'filesRequire': ['setup.js']
-                    }
+                    mainFile: ''
                 },
                 rootDistDir: path.resolve(baseFixturePath, './dist')
             }
@@ -81,14 +81,15 @@ describe('mocha', function () {
         const actionInfo = {
             testFiles,
             configFiles: [],
+            dynamicConfig: {
+                'require': ['babel-core/register', 'source-map-support/register'],
+                'filesRequire': ['setup.js']
+            },
+            rawConfig: {foo: 'bar'},
             context: {
                 componentDir: baseFixturePath,
                 componentObject: {
                     mainFile: '',
-                    dynamicConfig: {
-                        'require': ['babel-core/register', 'source-map-support/register'],
-                        'filesRequire': ['setup.js']
-                    }
                 },
                 rootDistDir: path.resolve(baseFixturePath, './dist')
             }
@@ -97,7 +98,7 @@ describe('mocha', function () {
             api:createApi()
         })
         let config = tester.getDynamicConfig!(actionInfo)
-        expect(config).to.deep.equal({})
+        expect(config).to.deep.equal(actionInfo.rawConfig)
     })
 })
 


### PR DESCRIPTION
The mocha env has the `filesRequire` functionality - before this fix it did not work. Now it works and a test for it was added.