### PR TITLE
test(jest): support for pre-requiring modules with setupTests

### DIFF
--- a/test/jest/fixture-action/jest.config.js
+++ b/test/jest/fixture-action/jest.config.js
@@ -13,6 +13,6 @@ module.exports = {
         "/node_modules/",
         "/.git/"
       ],
-      "setupFiles": [],
+      "setupFiles": ["<rootDir>/setup.js"],
       "testEnvironment": "node"
   };

--- a/test/jest/fixture-action/setup.js
+++ b/test/jest/fixture-action/setup.js
@@ -1,0 +1,1 @@
+global.jestSetupFilesRun = true

--- a/test/jest/fixture-action/test.spec.ts
+++ b/test/jest/fixture-action/test.spec.ts
@@ -11,4 +11,7 @@ describe('basic', function (){
     it('sub', function() {
         expect(sub(3, 1)).to.equal(2)
     })
+    it('supports preloading files with the jest `setupFiles` field', function() {
+        expect(global.jestSetupFilesRun).to.equal(true)
+    })
 })

--- a/test/jest/fixture-action/test.spec.ts
+++ b/test/jest/fixture-action/test.spec.ts
@@ -12,6 +12,6 @@ describe('basic', function (){
         expect(sub(3, 1)).to.equal(2)
     })
     it('supports preloading files with the jest `setupFiles` field', function() {
-        expect(global.jestSetupFilesRun).to.equal(true)
+        expect((global as any).jestSetupFilesRun).to.equal(true)
     })
 })


### PR DESCRIPTION
Fix for: https://github.com/teambit/bit-envs/issues/38
Since jest does not have a `--require` flag like mocha, the "jest way" of achieving this is using the `setupTests` config key. It already works but was untested - this is a test for it.