### PR TITLE
fix(mocha): do not parse non-json config file

### DIFF
--- a/src/find-configuration/find-configuration.ts
+++ b/src/find-configuration/find-configuration.ts
@@ -15,7 +15,7 @@ export const enum FindStrategy {
 
 export type findOptions = {
     [FindStrategy.pjKeyName]:string,
-    [FindStrategy.fileName]:string,
+    [FindStrategy.fileName]?:string,
     [FindStrategy.default]?: any,
     [FindStrategy.defaultFilePaths]?: Array<string>,
     strategy?: Array<FindStrategy>

--- a/src/find-configuration/find-configuration.ts
+++ b/src/find-configuration/find-configuration.ts
@@ -48,7 +48,7 @@ export const defaultGetBy:{[k:string]:any} = {
             return config
         }
         try {
-            const configVinyl = findByName(info.configFiles, options.fileName)
+            const configVinyl = findByName(info.configFiles, options.fileName || '')
             if (configVinyl) {
                 config.config = readConfigByFileEnding(configVinyl.path, configVinyl.contents!.toString())
             }

--- a/src/mocha/mocha.ts
+++ b/src/mocha/mocha.ts
@@ -123,12 +123,9 @@ function normalizeResults(mochaJsonResults: any, file: string) {
 
 
 export function mochaFindConfiguration(info:ExtensionApiOptions){
-    const fileName = 'mocha.opts'
     return findConfiguration(info, {
         [FindStrategy.pjKeyName]: 'mocha',
-        [FindStrategy.fileName]: fileName,
-        [FindStrategy.default]: {},
-        [FindStrategy.defaultFilePaths]: [`./test/${fileName}`],
+        [FindStrategy.default]: {}
     })
 }
 


### PR DESCRIPTION
Partial fix for https://github.com/teambit/bit-envs/issues/48

(for context, we also need this merged for the full workaround: https://github.com/teambit/bit-envs/pull/46)