### PR TITLE
 chore(lint): tslint + standard + editorconfig 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,8 @@ trim_trailing_whitespace = true
 indent_style = space
 
 [*.{js,jsx,ts,tsx}]
-indent_size = 4
+indent_size = 2
+max_line_length = 80
 
 [*.json]
 indent_size = 2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,7 +23,7 @@ include:
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-advances
+  advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
 ## Proposed Changes
 
-  -
-  -
-  -
+- - -

--- a/README.md
+++ b/README.md
@@ -32,5 +32,3 @@ We actively welcome your pull requests.
 
 By contributing to Bit, you agree that your contributions will be licensed
 under its [Apache2 license](LICENSE).
-
-

--- a/bit.json
+++ b/bit.json
@@ -1,9 +1,9 @@
 {
-    "env": {
-        "compiler": "bit.test-envs/typescript/index@0.0.3",
-        "tester": "bit.test-envs/testers/mocha@0.0.26"
-    },
-    "dependencies": {},
-    "componentsDefaultDirectory": "components/{namespace}/{name}",
-    "packageManager": "npm"
+  "env": {
+    "compiler": "bit.test-envs/typescript/index@0.0.3",
+    "tester": "bit.test-envs/testers/mocha@0.0.26"
+  },
+  "dependencies": {},
+  "componentsDefaultDirectory": "components/{namespace}/{name}",
+  "packageManager": "npm"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,12 @@
         }
       }
     },
+    "@sheerun/eslint-config-standard": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@sheerun/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+      "integrity": "sha512-aalIRUtcR6nPf50kEwnYvepSJIdpulrbMeeNMwiOmFgBg4MgScCmlI7SqOmsGJNqaH65+benoqt0H4N0RR2Okg==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
@@ -561,6 +567,23 @@
         "acorn": "^5.0.0"
       }
     },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
@@ -717,6 +740,21 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -941,6 +979,175 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+          "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.1.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+          "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+          "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.1.2",
+            "@babel/types": "^7.1.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+          "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.1.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.1.3",
+            "@babel/types": "^7.1.3",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/types": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+          "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+          "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
         }
       }
     },
@@ -2175,6 +2382,16 @@
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
           "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
           "dev": true
+        },
+        "typescript-eslint-parser": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz",
+          "integrity": "sha512-ZYYVKlHWR/RMvTCah4WfrZclb2azZipW4sbaYLJjbh6jiYn81tLUZAw/WdVLlXxaCbIawaKCA44AJPMFVArKZQ==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          }
         }
       }
     },
@@ -2423,6 +2640,23 @@
       "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw==",
       "dev": true
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        }
+      }
+    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -2558,6 +2792,12 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -2616,6 +2856,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2800,6 +3046,12 @@
       "requires": {
         "json-parser": "^1.0.0"
       }
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -3210,6 +3462,29 @@
       "integrity": "sha1-YuHc3R2Elwnlx0A8iQ5H486+OZ0=",
       "dev": true
     },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3379,6 +3654,12 @@
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.2.tgz",
+      "integrity": "sha512-xxD4VSH67GbRvSGUrckvha94RD7hjgOH7rqGxiytLpkaeMvixOHFZTGFK6EkIm3T761OVHT8ABHmGkq9gXgu6Q==",
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -3574,6 +3855,251 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "globals": {
+          "version": "11.8.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+          "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-typescript": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz",
+      "integrity": "sha512-2+DNE8nTvdNkhem/FBJXLPSeMDOZL68vHHNfTbM+PBc5iAuwBe8xLSQubwKxABqSZDwUHg+mwGmv5c2NlImi0Q==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
@@ -3583,10 +4109,35 @@
         "estraverse": "^4.1.1"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -3939,6 +4490,16 @@
         "object-assign": "^4.1.0"
       }
     },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
     "file-exists": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-2.0.0.tgz",
@@ -4024,6 +4585,18 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flush-write-stream": {
@@ -4589,6 +5162,12 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gauge": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
@@ -4727,6 +5306,28 @@
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
     },
     "globule": {
       "version": "1.2.1",
@@ -5595,6 +6196,30 @@
         "is-primitive": "^3.0.0"
       }
     },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -5638,6 +6263,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-2.0.0.tgz",
       "integrity": "sha1-vNCtPsI6STinfzQD0tv/NLmR+y8=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -6706,6 +7337,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -6899,6 +7536,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+    },
     "lodash.isnull": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
@@ -6909,6 +7551,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
@@ -6948,6 +7596,11 @@
       "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
       "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
       "dev": true
+    },
+    "lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
     },
     "lodash.set": {
       "version": "4.3.2",
@@ -7002,6 +7655,43 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "loglevel": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "lolex": {
@@ -7068,6 +7758,24 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
       "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
+    },
+    "make-plural": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.2.0.tgz",
+      "integrity": "sha512-zhDAr/erfvZtE1A66DIQ7ZNdGlexVGNDP1P1kvLZprRE0meA0zmxNbp6xmXzNRuZmgW0Ui4ibbaMPYPFHVRMkQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "makeerror": {
       "version": "1.0.11",
@@ -7290,6 +7998,41 @@
       "requires": {
         "readable-stream": "^2.0.1"
       }
+    },
+    "messageformat": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.1.1.tgz",
+      "integrity": "sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.0.6",
+        "make-plural": "^4.1.1",
+        "messageformat-parser": "^1.1.0",
+        "nopt": "~3.0.6",
+        "reserved-words": "^0.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "messageformat-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
+      "integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==",
+      "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
@@ -10394,6 +11137,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -10497,6 +11246,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "pn": {
@@ -10643,6 +11398,98 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "prettier-eslint": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.8.2.tgz",
+      "integrity": "sha512-2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^4.0.0",
+        "indent-string": "^3.2.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^1.7.0",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^2.5.1",
+        "typescript-eslint-parser": "^16.0.0",
+        "vue-eslint-parser": "^2.0.2"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "typescript-eslint-parser": {
+          "version": "16.0.1",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz",
+          "integrity": "sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          }
+        }
+      }
+    },
+    "prettier-standard": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-standard/-/prettier-standard-8.0.1.tgz",
+      "integrity": "sha512-egiIKvmlizoXuRkh83myjB4elmdIahCaUACLDaZyCgvspZQyps0fUayQpvcv4/gW/XahMTu95a3f9Fu8ouGYZw==",
+      "dev": true,
+      "requires": {
+        "@sheerun/eslint-config-standard": "^10.2.1",
+        "babel-eslint": ">=7.2.3",
+        "babel-runtime": "^6.23.0",
+        "chalk": "^2.3.0",
+        "core-js": "^2.5.3",
+        "eslint": "^4.7.2",
+        "find-up": "^2.1.0",
+        "get-stdin": "^5.0.1",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.3",
+        "indent-string": "^3.1.0",
+        "lodash.memoize": "^4.1.2",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "messageformat": "^1.0.2",
+        "minimist": "1.2.0",
+        "prettier": "1.9.x",
+        "prettier-eslint": "^8.1.1",
+        "regenerator-runtime": "^0.11.1",
+        "rxjs": "^5.4.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "pretty-format": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
@@ -10699,6 +11546,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -11002,6 +11855,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
@@ -11176,6 +12035,36 @@
         "is-nil-x": "^1.4.2"
       }
     },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
+    },
     "requirejs": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
@@ -11211,6 +12100,12 @@
           }
         }
       }
+    },
+    "reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
+      "dev": true
     },
     "resolve": {
       "version": "1.8.1",
@@ -11324,6 +12219,30 @@
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -12265,6 +13184,12 @@
         "get-stdin": "^4.0.1"
       }
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "stylable": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/stylable/-/stylable-5.2.2.tgz",
@@ -12348,6 +13273,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -12550,6 +13481,12 @@
       "version": "0.6.4",
       "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "textextensions": {
@@ -12874,6 +13811,94 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
+    "tslint": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      }
+    },
+    "tslint-config-standard": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-8.0.1.tgz",
+      "integrity": "sha512-OWG+NblgjQlVuUS/Dmq3ax2v5QDZwRx4L0kEuDi7qFY9UI6RJhhNfoCV1qI4el8Fw1c5a5BTrjQJP0/jhGXY/Q==",
+      "dev": true,
+      "requires": {
+        "tslint-eslint-rules": "^5.3.1"
+      }
+    },
+    "tslint-eslint-rules": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
+      "dev": true,
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.9.0",
+        "tsutils": "^3.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "^1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
+          "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -12951,9 +13976,19 @@
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz",
-      "integrity": "sha512-ZYYVKlHWR/RMvTCah4WfrZclb2azZipW4sbaYLJjbh6jiYn81tLUZAw/WdVLlXxaCbIawaKCA44AJPMFVArKZQ==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-20.0.0.tgz",
+      "integrity": "sha512-HZEoGA+LnS3etUlVAPX6I8sZ7872Yb0vPvQv6QDCIE44KD3bFmvPEQ4LbiD+qGkcxh6segjVK0v3rxpb2R6oSA==",
+      "dev": true,
+      "requires": {
+        "eslint": "4.19.1",
+        "typescript-estree": "2.1.0"
+      }
+    },
+    "typescript-estree": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-2.1.0.tgz",
+      "integrity": "sha512-t4o+7pB4OnxV36Bp41Vgtq8vXIvIUbx1vM98PSE2mL5QBY6woFaBN9hhD8pZHIrAu24IB5gzxbkEJOXj4lWNXQ==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -13299,6 +14334,38 @@
         "indexof": "0.0.1"
       }
     },
+    "vue-eslint-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+      "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
     "vue-template-compiler": {
       "version": "2.5.17",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
@@ -13528,6 +14595,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,12 +167,6 @@
         }
       }
     },
-    "@sheerun/eslint-config-standard": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@sheerun/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-      "integrity": "sha512-aalIRUtcR6nPf50kEwnYvepSJIdpulrbMeeNMwiOmFgBg4MgScCmlI7SqOmsGJNqaH65+benoqt0H4N0RR2Okg==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
@@ -979,175 +973,6 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-          "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.1.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-          "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-          "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.1.2",
-            "@babel/types": "^7.1.2"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-          "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.1.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.3",
-            "@babel/types": "^7.1.3",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-          "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.8.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-          "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
         }
       }
     },
@@ -3047,12 +2872,6 @@
         "json-parser": "^1.0.0"
       }
     },
-    "common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3654,12 +3473,6 @@
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
       }
-    },
-    "dlv": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.2.tgz",
-      "integrity": "sha512-xxD4VSH67GbRvSGUrckvha94RD7hjgOH7rqGxiytLpkaeMvixOHFZTGFK6EkIm3T761OVHT8ABHmGkq9gXgu6Q==",
-      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -7553,12 +7366,6 @@
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
@@ -7657,43 +7464,6 @@
         "chalk": "^2.0.1"
       }
     },
-    "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
-      "dev": true
-    },
-    "loglevel-colored-level-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
-      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "loglevel": "^1.4.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
@@ -7758,24 +7528,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
       "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
-    },
-    "make-plural": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.2.0.tgz",
-      "integrity": "sha512-zhDAr/erfvZtE1A66DIQ7ZNdGlexVGNDP1P1kvLZprRE0meA0zmxNbp6xmXzNRuZmgW0Ui4ibbaMPYPFHVRMkQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "makeerror": {
       "version": "1.0.11",
@@ -7998,41 +7750,6 @@
       "requires": {
         "readable-stream": "^2.0.1"
       }
-    },
-    "messageformat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.1.1.tgz",
-      "integrity": "sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==",
-      "dev": true,
-      "requires": {
-        "glob": "~7.0.6",
-        "make-plural": "^4.1.1",
-        "messageformat-parser": "^1.1.0",
-        "nopt": "~3.0.6",
-        "reserved-words": "^0.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "messageformat-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
-      "integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==",
-      "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
@@ -11398,98 +11115,6 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
-    "prettier": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
-      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
-      "dev": true
-    },
-    "prettier-eslint": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.8.2.tgz",
-      "integrity": "sha512-2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "common-tags": "^1.4.0",
-        "dlv": "^1.1.0",
-        "eslint": "^4.0.0",
-        "indent-string": "^3.2.0",
-        "lodash.merge": "^4.6.0",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "prettier": "^1.7.0",
-        "pretty-format": "^23.0.1",
-        "require-relative": "^0.8.7",
-        "typescript": "^2.5.1",
-        "typescript-eslint-parser": "^16.0.0",
-        "vue-eslint-parser": "^2.0.2"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "typescript-eslint-parser": {
-          "version": "16.0.1",
-          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz",
-          "integrity": "sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==",
-          "dev": true,
-          "requires": {
-            "lodash.unescape": "4.0.1",
-            "semver": "5.5.0"
-          }
-        }
-      }
-    },
-    "prettier-standard": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-standard/-/prettier-standard-8.0.1.tgz",
-      "integrity": "sha512-egiIKvmlizoXuRkh83myjB4elmdIahCaUACLDaZyCgvspZQyps0fUayQpvcv4/gW/XahMTu95a3f9Fu8ouGYZw==",
-      "dev": true,
-      "requires": {
-        "@sheerun/eslint-config-standard": "^10.2.1",
-        "babel-eslint": ">=7.2.3",
-        "babel-runtime": "^6.23.0",
-        "chalk": "^2.3.0",
-        "core-js": "^2.5.3",
-        "eslint": "^4.7.2",
-        "find-up": "^2.1.0",
-        "get-stdin": "^5.0.1",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.3",
-        "indent-string": "^3.1.0",
-        "lodash.memoize": "^4.1.2",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "messageformat": "^1.0.2",
-        "minimist": "1.2.0",
-        "prettier": "1.9.x",
-        "prettier-eslint": "^8.1.1",
-        "regenerator-runtime": "^0.11.1",
-        "rxjs": "^5.4.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "pretty-format": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
@@ -12035,12 +11660,6 @@
         "is-nil-x": "^1.4.2"
       }
     },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-      "dev": true
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -12100,12 +11719,6 @@
           }
         }
       }
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
-      "dev": true
     },
     "resolve": {
       "version": "1.8.1",
@@ -12233,15 +11846,6 @@
       "dev": true,
       "requires": {
         "rx-lite": "*"
-      }
-    },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -13273,12 +12877,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -14332,38 +13930,6 @@
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "requires": {
         "indexof": "0.0.1"
-      }
-    },
-    "vue-eslint-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
-      "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
-        "esquery": "^1.0.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
       }
     },
     "vue-template-compiler": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "build": "tsc -d",
     "test:watch": "mocha -w --require ts-node/register/transpile-only --require source-map-support/register test/**/*.spec.ts",
-    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register test/**/*.spec.ts",
-    "test:e2e": " mocha --require ts-node/register/transpile-only --require source-map-support/register test/**/*.e2e.ts",
+    "test": "npm run lint && npm run test-only",
+    "test-only": "mocha --require ts-node/register/transpile-only --require source-map-support/register test/**/*.spec.ts",
+    "test:e2e": "mocha --require ts-node/register/transpile-only --require source-map-support/register test/**/*.e2e.ts",
     "test:circle": "mocha --require ts-node/register/transpile-only --require source-map-support/register --reporter mocha-circleci-reporter test/**/*.spec.ts",
     "test:circle:e2e": "mocha --require ts-node/register/transpile-only --require source-map-support/register --reporter mocha-circleci-reporter test/**/*.e2e.ts",
     "test:ci": "npm run test && npm run test:e2e",
-    "clean": "rimraf ./dist/*"
+    "clean": "rimraf ./dist/*",
+    "lint": "tslint --project .",
+    "lint:fix": "prettier-standard **/*.ts"
   },
   "repository": {
     "type": "git",
@@ -40,16 +43,21 @@
     "bit-bin": "13.0.5-dev.8",
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
+    "eslint-plugin-typescript": "^0.12.0",
     "eval": "^0.1.2",
     "mocha": "^5.2.0",
     "mocha-circleci-reporter": "0.0.3",
     "nyc": "^12.0.2",
+    "prettier-standard": "^8.0.1",
     "rimraf": "^2.6.2",
     "sinon": "^6.3.4",
     "sinon-chai": "^3.2.0",
     "source-map-support": "^0.5.6",
     "ts-node": "^7.0.0",
-    "typescript": "^2.9.2"
+    "tslint": "^5.11.0",
+    "tslint-config-standard": "^8.0.1",
+    "typescript": "^2.9.2",
+    "typescript-eslint-parser": "^20.0.0"
   },
   "dependencies": {
     "babel-core": "^6.26.3",
@@ -64,6 +72,8 @@
     "json5": "^2.1.0",
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
+    "lodash.isnil": "^4.0.0",
+    "lodash.pickby": "^4.6.0",
     "memory-fs": "^0.4.1",
     "node-sass": "^4.9.3",
     "parse5": "^5.1.0",
@@ -91,5 +101,11 @@
       "html"
     ],
     "all": true
+  },
+  "standard": {
+    "parser": "typescript-eslint-parser",
+    "plugins": [
+      "typescript"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test:circle:e2e": "mocha --require ts-node/register/transpile-only --require source-map-support/register --reporter mocha-circleci-reporter test/**/*.e2e.ts",
     "test:ci": "npm run test && npm run test:e2e",
     "clean": "rimraf ./dist/*",
-    "lint": "tslint --project .",
-    "lint:fix": "prettier-standard **/*.ts"
+    "lint": "tslint --project ."
   },
   "repository": {
     "type": "git",
@@ -48,7 +47,6 @@
     "mocha": "^5.2.0",
     "mocha-circleci-reporter": "0.0.3",
     "nyc": "^12.0.2",
-    "prettier-standard": "^8.0.1",
     "rimraf": "^2.6.2",
     "sinon": "^6.3.4",
     "sinon-chai": "^3.2.0",
@@ -101,11 +99,5 @@
       "html"
     ],
     "all": true
-  },
-  "standard": {
-    "parser": "typescript-eslint-parser",
-    "plugins": [
-      "typescript"
-    ]
   }
 }

--- a/src/babel-dependencies/babel-dependencies.ts
+++ b/src/babel-dependencies/babel-dependencies.ts
@@ -1,55 +1,90 @@
-import { Logger, ExtensionApiOptions, fillDependencyVersion, loadPackageJsonSync} from '../env-utils';
-import { findConfiguration, FindStrategy } from '../find-configuration';
-import {defaultConfig} from './default-babel-config'
+import {
+  Logger,
+  ExtensionApiOptions,
+  fillDependencyVersion,
+  loadPackageJsonSync
+} from '../env-utils'
+import { findConfiguration, FindStrategy } from '../find-configuration'
+import { defaultConfig } from './default-babel-config'
 
 import _get from 'lodash.get'
 
-export function getBabelDynamicPackageDependencies(_logger:Logger, name = '.babelrc') {
-    return function (info: ExtensionApiOptions) {
-        const dynamicPackageDependencies = {}
-        const babelrcFromFind = babelFindConfiguration(info, name)
-        const babelrc = _get(babelrcFromFind, 'config.babel', babelrcFromFind.config)
+export function getBabelDynamicPackageDependencies (
+  _logger: Logger,
+  name = '.babelrc'
+) {
+  return function (info: ExtensionApiOptions) {
+    const dynamicPackageDependencies = {}
+    const babelrcFromFind = babelFindConfiguration(info, name)
+    const babelrc = _get(
+      babelrcFromFind,
+      'config.babel',
+      babelrcFromFind.config
+    )
 
-        const pluginsNames = babelrc.plugins ?
-            babelrc.plugins.map((pluginName:string|Array<string>)=> Array.isArray(pluginName) ? pluginName[0]: pluginName) :
-            []
-        const presetsNames = babelrc.presets || []
-        const addParsedNameToResult = (result: {[key:string]:string}, packageJson: object, nameToPackageFn: (name:string) => string) => (name: string) => {
-            const packageName = nameToPackageFn(name)
-            fillDependencyVersion(packageJson, packageName, result)
-        }
-        if (pluginsNames.length || presetsNames.length) {
-            const workspaceDir = info.context && info.context.workspaceDir
-            const componentDir = info.context && info.context.componentDir
-            const packageJson = loadPackageJsonSync(componentDir, workspaceDir)
-            pluginsNames.map(addParsedNameToResult(dynamicPackageDependencies, packageJson, getPluginPackageName))
-            presetsNames.map(addParsedNameToResult(dynamicPackageDependencies, packageJson, getPresetPackageName))
-        }
-
-        return dynamicPackageDependencies
+    const pluginsNames = babelrc.plugins
+      ? babelrc.plugins.map(
+        (pluginName: string | Array<string>) =>
+          Array.isArray(pluginName) ? pluginName[0] : pluginName
+      )
+      : []
+    const presetsNames = babelrc.presets || []
+    const addParsedNameToResult = (
+      result: { [key: string]: string },
+      packageJson: object,
+      nameToPackageFn: (name: string) => string
+    ) => (name: string) => {
+      const packageName = nameToPackageFn(name)
+      fillDependencyVersion(packageJson, packageName, result)
     }
+    if (pluginsNames.length || presetsNames.length) {
+      const workspaceDir = info.context && info.context.workspaceDir
+      const componentDir = info.context && info.context.componentDir
+      const packageJson = loadPackageJsonSync(componentDir, workspaceDir)
+      pluginsNames.map(
+        addParsedNameToResult(
+          dynamicPackageDependencies,
+          packageJson,
+          getPluginPackageName
+        )
+      )
+      presetsNames.map(
+        addParsedNameToResult(
+          dynamicPackageDependencies,
+          packageJson,
+          getPresetPackageName
+        )
+      )
+    }
+
+    return dynamicPackageDependencies
+  }
 }
 
-export function getPluginPackageName(pluginName: string) {
-    const prefix = 'babel-plugin'
-    return getPrefixedPackageName(pluginName, prefix)
+export function getPluginPackageName (pluginName: string) {
+  const prefix = 'babel-plugin'
+  return getPrefixedPackageName(pluginName, prefix)
 }
 
-export function getPresetPackageName(pluginName: string) {
-    const prefix = 'babel-preset'
-    return getPrefixedPackageName(pluginName, prefix)
+export function getPresetPackageName (pluginName: string) {
+  const prefix = 'babel-preset'
+  return getPrefixedPackageName(pluginName, prefix)
 }
 
-export function getPrefixedPackageName(pluginName: string, prefix: string) {
-    return pluginName.indexOf(prefix) !== 0 ? `${prefix}-${pluginName}` : pluginName
+export function getPrefixedPackageName (pluginName: string, prefix: string) {
+  return pluginName.indexOf(prefix) !== 0
+    ? `${prefix}-${pluginName}`
+    : pluginName
 }
 
-
-export function babelFindConfiguration(info:ExtensionApiOptions, name:string){
-    return findConfiguration(info, {
-        [FindStrategy.pjKeyName]: 'babel',
-        [FindStrategy.fileName]: name,
-        [FindStrategy.default]: defaultConfig,
-        [FindStrategy.defaultFilePaths]: ['./.babelrc', './babel.config.js'],
-    })
+export function babelFindConfiguration (
+  info: ExtensionApiOptions,
+  name: string
+) {
+  return findConfiguration(info, {
+    [FindStrategy.pjKeyName]: 'babel',
+    [FindStrategy.fileName]: name,
+    [FindStrategy.default]: defaultConfig,
+    [FindStrategy.defaultFilePaths]: ['./.babelrc', './babel.config.js']
+  })
 }

--- a/src/babel-dependencies/default-babel-config.ts
+++ b/src/babel-dependencies/default-babel-config.ts
@@ -1,17 +1,17 @@
 export const defaultConfig = {
-    presets: ["latest", "react"],
-    sourceMaps: true,
-    ast: false,
-    minified: false,
-    plugins: [
-        ["transform-object-rest-spread", { useBuiltIns: true }],
-        "transform-decorators-legacy",
-        "transform-object-entries",
-        "object-values-to-object-keys",
-        "transform-export-extensions",
-        "transform-class-properties",
-        "transform-async-to-generator",
-        ["transform-react-jsx", { useBuiltIns: true }],
-        ["transform-regenerator", { async: false }]
-    ]
+  presets: ['latest', 'react'],
+  sourceMaps: true,
+  ast: false,
+  minified: false,
+  plugins: [
+    ['transform-object-rest-spread', { useBuiltIns: true }],
+    'transform-decorators-legacy',
+    'transform-object-entries',
+    'object-values-to-object-keys',
+    'transform-export-extensions',
+    'transform-class-properties',
+    'transform-async-to-generator',
+    ['transform-react-jsx', { useBuiltIns: true }],
+    ['transform-regenerator', { async: false }]
+  ]
 }

--- a/src/babel-dependencies/index.ts
+++ b/src/babel-dependencies/index.ts
@@ -1,6 +1,6 @@
 export {
-    getBabelDynamicPackageDependencies,
-    babelFindConfiguration,
-    getPresetPackageName,
-    getPluginPackageName
+  getBabelDynamicPackageDependencies,
+  babelFindConfiguration,
+  getPresetPackageName,
+  getPluginPackageName
 } from './babel-dependencies'

--- a/src/babel/babel-core.d.ts
+++ b/src/babel/babel-core.d.ts
@@ -1,1 +1,1 @@
-declare module 'babel-core';
+declare module 'babel-core'

--- a/src/babel/babel.ts
+++ b/src/babel/babel.ts
@@ -1,101 +1,124 @@
 import { CompilerExtension, API, ExtensionApiOptions } from '../env-utils/types'
 import Vinyl from 'vinyl'
 import {
-    getPluginPackageName,
-    getPresetPackageName,
+  getPluginPackageName,
+  getPresetPackageName,
+  babelFindConfiguration,
+  getBabelDynamicPackageDependencies
 } from '../babel-dependencies'
 import resolve from 'resolve'
 import path from 'path'
 import * as babel from 'babel-core'
 import _get from 'lodash.get'
-import { babelFindConfiguration, getBabelDynamicPackageDependencies } from '../babel-dependencies';
 
-export function CreateBabelCompiler(name = '.babelrc') {
-    const metaBabelCompiler: CompilerExtension = {
-        init: function ({ api }: { api: API }) {
-            metaBabelCompiler.logger = api.getLogger()
-            return {
-                write: true
-            }
-        },
-        getDynamicConfig: function(info: ExtensionApiOptions){
-            let config = babelFindConfiguration(info, name)
-            return config.save ? config.config : {}
-        },
-        action: function (info: ExtensionApiOptions) {
-            const babelrcFromfind = babelFindConfiguration(info, name)
-            const babelrc = _get(babelrcFromfind, 'config.babel', babelrcFromfind.config)
+export function CreateBabelCompiler (name = '.babelrc') {
+  const metaBabelCompiler: CompilerExtension = {
+    init: function ({ api }: { api: API }) {
+      metaBabelCompiler.logger = api.getLogger()
+      return {
+        write: true
+      }
+    },
+    getDynamicConfig: function (info: ExtensionApiOptions) {
+      let config = babelFindConfiguration(info, name)
+      return config.save ? config.config : {}
+    },
+    action: function (info: ExtensionApiOptions) {
+      const babelrcFromfind = babelFindConfiguration(info, name)
+      const babelrc = _get(
+        babelrcFromfind,
+        'config.babel',
+        babelrcFromfind.config
+      )
 
-            const componentDir = info.context && info.context.componentDir
+      const componentDir = info.context && info.context.componentDir
 
-            if (componentDir) {
-                babelrc.plugins = _get(babelrc, 'plugins', []).map((pluginName: string |Array<string>) => {
-                    const actualPluginName = Array.isArray(pluginName) ? pluginName[0]: pluginName
-                    return resolvePlugin(componentDir, actualPluginName)
-                })
-                babelrc.presets = _get(babelrc,'presets', []).map((presetName: string) => resolvePreset(componentDir, presetName))
-            }
-            const builtFiles: {files:Array<Vinyl>, errors:Array<any>} = (info.files || [])
-                .map((file:Vinyl) => runBabel(file, babelrc, info.context.rootDistDir))
-                .reduce((a:any, b:any):any => {
-                    return {
-                        errors: a.errors.concat(b.errors),
-                        files: a.files.concat(b.files)
-                    }
-                })
-            return !builtFiles.errors.length ? Promise.resolve(builtFiles): Promise.reject(builtFiles.errors)
-        },
-        getDynamicPackageDependencies: function (info){
-            return getBabelDynamicPackageDependencies(metaBabelCompiler.logger!, name)(info)
-        }
+      if (componentDir) {
+        babelrc.plugins = _get(babelrc, 'plugins', []).map(
+          (pluginName: string | Array<string>) => {
+            const actualPluginName = Array.isArray(pluginName)
+              ? pluginName[0]
+              : pluginName
+            return resolvePlugin(componentDir, actualPluginName)
+          }
+        )
+        babelrc.presets = _get(babelrc, 'presets', []).map(
+          (presetName: string) => resolvePreset(componentDir, presetName)
+        )
+      }
+      const builtFiles: { files: Array<Vinyl>; errors: Array<any> } = (
+        info.files || []
+      )
+        .map((file: Vinyl) => runBabel(file, babelrc, info.context.rootDistDir))
+        .reduce((a: any, b: any): any => {
+          return {
+            errors: a.errors.concat(b.errors),
+            files: a.files.concat(b.files)
+          }
+        })
+      return !builtFiles.errors.length
+        ? Promise.resolve(builtFiles)
+        : Promise.reject(builtFiles.errors)
+    },
+    getDynamicPackageDependencies: function (info) {
+      return getBabelDynamicPackageDependencies(
+        metaBabelCompiler.logger!,
+        name
+      )(info)
     }
-    return metaBabelCompiler
+  }
+  return metaBabelCompiler
 }
 
-
-function resolvePlugin(componentDir: string, pluginName: string) {
-    const resolvedName = getPluginPackageName(pluginName)
-    return resolvePackagesFromComponentDir(componentDir, resolvedName)
+function resolvePlugin (componentDir: string, pluginName: string) {
+  const resolvedName = getPluginPackageName(pluginName)
+  return resolvePackagesFromComponentDir(componentDir, resolvedName)
 }
 
-function resolvePreset(componentDir: string, presetName: string) {
-    const resolvedName = getPresetPackageName(presetName)
-    return resolvePackagesFromComponentDir(componentDir, resolvedName)
+function resolvePreset (componentDir: string, presetName: string) {
+  const resolvedName = getPresetPackageName(presetName)
+  return resolvePackagesFromComponentDir(componentDir, resolvedName)
 }
 
-function resolvePackagesFromComponentDir(componentDir: string, packagName: string) {
-    // This might be done using the paths option in node's built in require.resolve function
-    // but this option is only supported since node v8.9.0 so in order to support older versions
-    // we used this package
-    // const resolvedPackage = require.resolve(packagName, { paths: [componentDir] })
-    const resolvedPackage = resolve.sync(packagName, { basedir: componentDir })
-    return resolvedPackage
+function resolvePackagesFromComponentDir (
+  componentDir: string,
+  packagName: string
+) {
+  // This might be done using the paths option in node's
+  // built in require.resolve function
+  // but this option is only supported since node v8.9.0
+  // so in order to support older versions
+  // we used this package
+  const resolvedPackage = resolve.sync(packagName, { basedir: componentDir })
+  return resolvedPackage
 }
 
-function runBabel(file:Vinyl, options:object, distPath:string) {
-    const adjustedOptions = Object.assign({}, options, {
-        filename:file.relative
-    })
-    let r
-    try {
-        r = babel.transform(file.contents!.toString(), adjustedOptions)
-    } catch(e){
-        return {files:[], errors:[e]}
-    }
-    if (r.ignored) {
-        return {files:[], errors:[]}
-    }
-    const mappings = new Vinyl({
-        contents: Buffer.from(_get(r, 'map.mappings', '')),
-        base: distPath,
-        path: path.join(distPath, file.relative),
-        basename: `${file.basename}.map`
-    })
-    const distFile = file.clone()
-    distFile.base = distPath
-    distFile.path = path.join(distPath, file.relative)
-    distFile.contents = r.code ? Buffer.from(`${r.code}\n\n//# sourceMappingURL=${mappings.basename}`) : Buffer.from(r.code!)
-    return {files:[mappings, distFile], errors: []}
+function runBabel (file: Vinyl, options: object, distPath: string) {
+  const adjustedOptions = Object.assign({}, options, {
+    filename: file.relative
+  })
+  let r
+  try {
+    r = babel.transform(file.contents!.toString(), adjustedOptions)
+  } catch (e) {
+    return { files: [], errors: [e] }
+  }
+  if (r.ignored) {
+    return { files: [], errors: [] }
+  }
+  const mappings = new Vinyl({
+    contents: Buffer.from(_get(r, 'map.mappings', '')),
+    base: distPath,
+    path: path.join(distPath, file.relative),
+    basename: `${file.basename}.map`
+  })
+  const distFile = file.clone()
+  distFile.base = distPath
+  distFile.path = path.join(distPath, file.relative)
+  distFile.contents = r.code
+    ? Buffer.from(`${r.code}\n\n//# sourceMappingURL=${mappings.basename}`)
+    : Buffer.from(r.code)
+  return { files: [mappings, distFile], errors: [] }
 }
 
 export default CreateBabelCompiler()

--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -1,4 +1,3 @@
-import {default as babelCompiler} from './babel'
-export {CreateBabelCompiler} from './babel'
+import { default as babelCompiler } from './babel'
+export { CreateBabelCompiler } from './babel'
 export default babelCompiler
-

--- a/src/env-utils/compiler-utils.ts
+++ b/src/env-utils/compiler-utils.ts
@@ -3,45 +3,56 @@ import fs from 'fs-extra'
 import _get from 'lodash.get'
 import Vinyl from 'vinyl'
 
-export function loadPackageJsonSync(componentDir: string, workspaceDir: string) {
-    const packageJsonName = 'package.json'
-    let packageJsonPath
-    if (componentDir) {
-        packageJsonPath = path.join(componentDir, packageJsonName)
-        const packageJson =  loadPackageJsonFromPathSync(packageJsonPath)
-        if (packageJson) {
-            return packageJson
-        }
+export function loadPackageJsonSync (
+  componentDir: string,
+  workspaceDir: string
+) {
+  const packageJsonName = 'package.json'
+  let packageJsonPath
+  if (componentDir) {
+    packageJsonPath = path.join(componentDir, packageJsonName)
+    const packageJson = loadPackageJsonFromPathSync(packageJsonPath)
+    if (packageJson) {
+      return packageJson
     }
+  }
 
-    packageJsonPath = path.join(workspaceDir, packageJsonName)
-    return loadPackageJsonFromPathSync(packageJsonPath)
+  packageJsonPath = path.join(workspaceDir, packageJsonName)
+  return loadPackageJsonFromPathSync(packageJsonPath)
 }
 
-function loadPackageJsonFromPathSync(packageJsonPath: string) {
-    return fs.pathExistsSync(packageJsonPath) ? fs.readJsonSync(packageJsonPath) : undefined
+function loadPackageJsonFromPathSync (packageJsonPath: string) {
+  return fs.pathExistsSync(packageJsonPath)
+    ? fs.readJsonSync(packageJsonPath)
+    : undefined
 }
 
-export function getVersion(packageJSON:object, name:string) {
-    return _get(packageJSON, `dependencies[${name}]`) ||
-            _get(packageJSON, `devDependencies[${name}]`) ||
-            _get(packageJSON, `peerDependencies[${name}]`)
+export function getVersion (packageJSON: object, name: string) {
+  return (
+    _get(packageJSON, `dependencies[${name}]`) ||
+    _get(packageJSON, `devDependencies[${name}]`) ||
+    _get(packageJSON, `peerDependencies[${name}]`)
+  )
 }
 
-export function fillDependencyVersion(packageJson: object, name: string, toFill: {[k:string]:string}) {
-    const version = getVersion(packageJson, name)
-    if (version) {
-        toFill[name] = version
-    }
-    return version
+export function fillDependencyVersion (
+  packageJson: object,
+  name: string,
+  toFill: { [k: string]: string }
+) {
+  const version = getVersion(packageJson, name)
+  if (version) {
+    toFill[name] = version
+  }
+  return version
 }
 
-export function findByName(files:Array<Vinyl> , name:string){
-    const file = files.find((config:Vinyl) => {
-        return config.name === name
-    })
-    if (!file){
-        throw new Error(`Could not find ${name}`)
-    }
-    return file
+export function findByName (files: Array<Vinyl>, name: string) {
+  const file = files.find((config: Vinyl) => {
+    return config.name === name
+  })
+  if (!file) {
+    throw new Error(`Could not find ${name}`)
+  }
+  return file
 }

--- a/src/env-utils/index.ts
+++ b/src/env-utils/index.ts
@@ -1,23 +1,19 @@
 export {
-    fillDependencyVersion,
-    findByName,
-    getVersion,
-    loadPackageJsonSync
+  fillDependencyVersion,
+  findByName,
+  getVersion,
+  loadPackageJsonSync
 } from './compiler-utils'
 
 export {
-    ActionTesterOptions,
-    API,
-    CompilerExtension,
-    ExtensionApiOptions,
-    Logger,
-    Options,
-    TesterExtension,
-    TestResult
+  ActionTesterOptions,
+  API,
+  CompilerExtension,
+  ExtensionApiOptions,
+  Logger,
+  Options,
+  TesterExtension,
+  TestResult
 } from './types'
 
-
-export {
-    cleanPrivateRequire,
-    createPrivateRequire
-} from './private-require'
+export { cleanPrivateRequire, createPrivateRequire } from './private-require'

--- a/src/env-utils/private-require.ts
+++ b/src/env-utils/private-require.ts
@@ -4,26 +4,39 @@ import fs from 'fs-extra'
 const IGNORE_FOLDER = '.bitTmp'
 const defaultBodyExpression = 'require(pathToModule)'
 
-export function createPrivateRequire(directory:string, bodyExpression = defaultBodyExpression, folder = IGNORE_FOLDER) {
-    const privateRequireContent = `
+export function createPrivateRequire (
+  directory: string,
+  bodyExpression = defaultBodyExpression,
+  folder = IGNORE_FOLDER
+) {
+  const privateRequireContent = `
     function privateRequire(pathToModule){
         return ${bodyExpression}
     }
     module.exports = privateRequire
     `
-    const tempFolderInComp = path.resolve(directory, folder)
-    if(!fs.existsSync(tempFolderInComp)) {
-        fs.mkdirpSync(tempFolderInComp)
-    }
-    const pathToDynamicScript = path.resolve(tempFolderInComp, 'private-require.js')
-    fs.writeFileSync(pathToDynamicScript, privateRequireContent, { encoding:'utf8' })
+  const tempFolderInComp = path.resolve(directory, folder)
+  if (!fs.existsSync(tempFolderInComp)) {
+    fs.mkdirpSync(tempFolderInComp)
+  }
+  const pathToDynamicScript = path.resolve(
+    tempFolderInComp,
+    'private-require.js'
+  )
+  fs.writeFileSync(pathToDynamicScript, privateRequireContent, {
+    encoding: 'utf8'
+  })
 
-    return require(pathToDynamicScript)
-
+  return require(pathToDynamicScript)
 }
 
-export function cleanPrivateRequire(directory:string , folder = IGNORE_FOLDER) {
-    const pathToDynamicScript = path.resolve(directory, folder, 'private-require.js')
-    fs.unlinkSync(pathToDynamicScript)
-
+export function cleanPrivateRequire (
+    directory: string, folder = IGNORE_FOLDER
+) {
+  const pathToDynamicScript = path.resolve(
+    directory,
+    folder,
+    'private-require.js'
+  )
+  fs.unlinkSync(pathToDynamicScript)
 }

--- a/src/env-utils/types.ts
+++ b/src/env-utils/types.ts
@@ -1,49 +1,52 @@
 import Vinyl from 'vinyl'
 
 export interface API {
-    getLogger: () => Logger
+  getLogger: () => Logger
 }
 export interface Logger {
-    log:Function,
-    error:Function
+  log: Function
+  error: Function
 }
 export interface Options {
-    write: boolean
+  write: boolean
 }
 // spilt interfaces
 export interface ExtensionApiOptions {
-    files?: Array<Vinyl>
-    rawConfig?: object
-    dynamicConfig?: object
-    configFiles: Array<Vinyl>
-    api?: any
-    context: any
+  files?: Array<Vinyl>
+  rawConfig?: object
+  dynamicConfig?: object
+  configFiles: Array<Vinyl>
+  api?: any
+  context: any
 }
 
 export interface ActionTesterOptions extends ExtensionApiOptions {
-    testFiles: Array<Vinyl>
+  testFiles: Array<Vinyl>
 }
 
 export interface CompilerExtension {
-    init: ({ api }: { api: API }) => Options
-    action: (info: ExtensionApiOptions) => Promise<{files: Array<Vinyl>}>
-    getDynamicPackageDependencies: (info: ExtensionApiOptions, name?:string) => object
-    logger?: Logger
-    getDynamicConfig?: (info: ExtensionApiOptions) => any
+  init: ({ api }: { api: API }) => Options
+  action: (info: ExtensionApiOptions) => Promise<{ files: Array<Vinyl> }>
+  getDynamicPackageDependencies: (
+    info: ExtensionApiOptions,
+    name?: string
+  ) => object
+  logger?: Logger
+  getDynamicConfig?: (info: ExtensionApiOptions) => any
 }
 
 export interface TesterExtension {
-    logger?: Logger
-    init: ({ api }: { api: API }) => Options
-    action: (info: ActionTesterOptions) => Promise<Array<any>>
-    getDynamicPackageDependencies: (info: ExtensionApiOptions) => object
-    getDynamicConfig?: (info: ActionTesterOptions) => any
+  logger?: Logger
+  init: ({ api }: { api: API }) => Options
+  action: (info: ActionTesterOptions) => Promise<Array<any>>
+  getDynamicPackageDependencies: (info: ExtensionApiOptions) => object
+  getDynamicConfig?: (info: ActionTesterOptions) => any
 }
 
 export interface TestResult {
-    title: string
-    fullTitle: string
-    duration: number | undefined
-    currentRetry: number
-    err: object
+  title: string
+  fullTitle: string
+  duration: number | undefined
+  currentRetry: number
+  err: object
 }

--- a/src/find-configuration/find-configuration.ts
+++ b/src/find-configuration/find-configuration.ts
@@ -1,119 +1,162 @@
-
-import { loadPackageJsonSync, findByName, ExtensionApiOptions } from '../env-utils';
+import {
+  loadPackageJsonSync,
+  findByName,
+  ExtensionApiOptions
+} from '../env-utils'
 import _ from 'lodash'
 import path from 'path'
 import fs from 'fs-extra'
 
 export const enum FindStrategy {
-    fileName = 'fileName',
-    raw = 'raw',
-    pjKeyName = 'pjKeyName',
-    default = 'default',
-    defaultFilePaths = 'defaultFilePaths',
-    dynamicConfig = 'dynamicConfig'
+  fileName = 'fileName',
+  raw = 'raw',
+  pjKeyName = 'pjKeyName',
+  default = 'default',
+  defaultFilePaths = 'defaultFilePaths',
+  dynamicConfig = 'dynamicConfig'
 }
 
 export type findOptions = {
-    [FindStrategy.pjKeyName]:string,
-    [FindStrategy.fileName]?:string,
-    [FindStrategy.default]?: any,
-    [FindStrategy.defaultFilePaths]?: Array<string>,
-    strategy?: Array<FindStrategy>
+  [FindStrategy.pjKeyName]: string
+  [FindStrategy.fileName]?: string
+  [FindStrategy.default]?: any
+  [FindStrategy.defaultFilePaths]?: Array<string>
+  strategy?: Array<FindStrategy>
 }
 
-export const defaultGetBy:{[k:string]:any} = {
-    [FindStrategy.dynamicConfig]: function (info:ExtensionApiOptions, _options:findOptions) {
-        const config = {config:null, save:false}
-        if (info.dynamicConfig && !_.isEqual(info.dynamicConfig, {}) && !_.isEqual(info.dynamicConfig, info.rawConfig)) {
-            config.config = (info.dynamicConfig as any)
-        }
-        return config
-    },
-    [FindStrategy.defaultFilePaths]: function (info:ExtensionApiOptions, options:findOptions) {
-        const config = { config: null, save: false}
-        const paths:Array<string> = options.defaultFilePaths || []
-        for (const configPath of paths) {
-            const correctFolder =  _.get(info, 'context.componentDir', '') || _.get(info, 'context.componentDir', '')
-            const fullConfigPath = path.resolve(correctFolder, configPath)
-            if(fs.existsSync(fullConfigPath)){
-                config.config = readConfigByFileEnding(fullConfigPath)
-                config.save = !!config.config
-            }
-        }
-        return config
-    },
-    [FindStrategy.fileName]: function (info:ExtensionApiOptions, options:findOptions) {
-        const config = { config: null, save: false}
-        if (!info.configFiles){
-            return config
-        }
-        try {
-            const configVinyl = findByName(info.configFiles, options.fileName || '')
-            if (configVinyl) {
-                config.config = readConfigByFileEnding(configVinyl.path, configVinyl.contents!.toString())
-            }
-
-        } catch(e) {}
-        return config
-    },
-    [FindStrategy.default]: function (_info:ExtensionApiOptions, options:findOptions) {
-        return {
-            config: options.default ? options.default : null,
-            save: false
-        }
-
-    },
-    [FindStrategy.raw]: function(info:ExtensionApiOptions, options:findOptions) {
-        return {
-            config: Object.keys(_.get(info, `rawConfig.${options.pjKeyName}`, {})).length > 0 ?
-                _.get(info, `rawConfig.${options.pjKeyName}`, {}) :
-                null,
-            save: false
-        }
-    },
-    [FindStrategy.pjKeyName]: function(info:ExtensionApiOptions, options:findOptions){
-        const workspaceDir = info.context && info.context.workspaceDir
-        const componentDir = info.context && info.context.componentDir
-        let packageJson:{[k:string]:any} = {}
-        try {
-            packageJson = loadPackageJsonSync(componentDir, workspaceDir)
-        } catch(e){}
-
-        return {
-            config: packageJson && packageJson[options.pjKeyName] ? {[options.pjKeyName]:packageJson[options.pjKeyName]} : null,
-            save: !!(packageJson && packageJson[options.pjKeyName])
-        }
+export const defaultGetBy: { [k: string]: any } = {
+  [FindStrategy.dynamicConfig]: function (
+    info: ExtensionApiOptions,
+    _options: findOptions
+  ) {
+    const config = { config: null, save: false }
+    if (
+      info.dynamicConfig &&
+      !_.isEqual(info.dynamicConfig, {}) &&
+      !_.isEqual(info.dynamicConfig, info.rawConfig)
+    ) {
+      config.config = info.dynamicConfig as any
     }
-}
-
-export function findConfiguration(info:ExtensionApiOptions, options:findOptions, getBy = defaultGetBy){
-    const defaultStrategy =  [
-        FindStrategy.dynamicConfig,
-        FindStrategy.fileName,
-        FindStrategy.defaultFilePaths,
-        FindStrategy.raw,
-        FindStrategy.pjKeyName,
-        FindStrategy.default
-    ]
-    const strategy:Array<FindStrategy> =  options.strategy || defaultStrategy
-    const config:{config:any, save:boolean} = {config: {}, save: false}
-    for (let method of strategy) {
-
-        const configLookup = !!getBy[method] ? getBy[method](info, options): (console.log('unknown strategy to load configuration'), null)
-        if (configLookup.config) {
-            Object.assign(config.config, configLookup.config)
-            config.save = configLookup.save
-            break
-        }
-    }
-    config.config = {...config.config, ...(getBy.raw(info, options).config || {})}
     return config
+  },
+  [FindStrategy.defaultFilePaths]: function (
+    info: ExtensionApiOptions,
+    options: findOptions
+  ) {
+    const config = { config: null, save: false }
+    const paths: Array<string> = options.defaultFilePaths || []
+    for (const configPath of paths) {
+      const correctFolder =
+        _.get(info, 'context.componentDir', '') ||
+        _.get(info, 'context.componentDir', '')
+      const fullConfigPath = path.resolve(correctFolder, configPath)
+      if (fs.existsSync(fullConfigPath)) {
+        config.config = readConfigByFileEnding(fullConfigPath)
+        config.save = !!config.config
+      }
+    }
+    return config
+  },
+  [FindStrategy.fileName]: function (
+    info: ExtensionApiOptions,
+    options: findOptions
+  ) {
+    const config = { config: null, save: false }
+    if (!info.configFiles) {
+      return config
+    }
+    try {
+      const configVinyl = findByName(info.configFiles, options.fileName || '')
+      if (configVinyl) {
+        config.config = readConfigByFileEnding(
+          configVinyl.path,
+          configVinyl.contents!.toString()
+        )
+      }
+    } catch (e) {
+      // do nothing
+    }
+    return config
+  },
+  [FindStrategy.default]: function (
+    _info: ExtensionApiOptions,
+    options: findOptions
+  ) {
+    return {
+      config: options.default ? options.default : null,
+      save: false
+    }
+  },
+  [FindStrategy.raw]: function (
+    info: ExtensionApiOptions,
+    options: findOptions
+  ) {
+    return {
+      config:
+        Object.keys(_.get(info, `rawConfig.${options.pjKeyName}`, {})).length >
+        0
+          ? _.get(info, `rawConfig.${options.pjKeyName}`, {})
+          : null,
+      save: false
+    }
+  },
+  [FindStrategy.pjKeyName]: function (
+    info: ExtensionApiOptions,
+    options: findOptions
+  ) {
+    const workspaceDir = info.context && info.context.workspaceDir
+    const componentDir = info.context && info.context.componentDir
+    let packageJson: { [k: string]: any } = {}
+    try {
+      packageJson = loadPackageJsonSync(componentDir, workspaceDir)
+    } catch (e) {
+      // do nothing
+    }
+
+    return {
+      config:
+        packageJson && packageJson[options.pjKeyName]
+          ? { [options.pjKeyName]: packageJson[options.pjKeyName] }
+          : null,
+      save: !!(packageJson && packageJson[options.pjKeyName])
+    }
+  }
 }
 
-function readConfigByFileEnding(configPath:string, content = '' ){
-    return configPath.endsWith('.js') ?
-        require(configPath) :
-        content ?
-        JSON.parse(content) :
-        fs.readJsonSync(configPath)
+export function findConfiguration (
+  info: ExtensionApiOptions,
+  options: findOptions,
+  getBy = defaultGetBy
+) {
+  const defaultStrategy = [
+    FindStrategy.dynamicConfig,
+    FindStrategy.fileName,
+    FindStrategy.defaultFilePaths,
+    FindStrategy.raw,
+    FindStrategy.pjKeyName,
+    FindStrategy.default
+  ]
+  const strategy: Array<FindStrategy> = options.strategy || defaultStrategy
+  const config: { config: any; save: boolean } = { config: {}, save: false }
+  for (let method of strategy) {
+    const configLookup = getBy[method]
+      ? getBy[method](info, options)
+      : (console.log('unknown strategy to load configuration'), null)
+    if (configLookup.config) {
+      Object.assign(config.config, configLookup.config)
+      config.save = configLookup.save
+      break
+    }
+  }
+  config.config = {
+    ...config.config,
+    ...(getBy.raw(info, options).config || {})
+  }
+  return config
+}
+
+function readConfigByFileEnding (configPath: string, content = '') {
+  return configPath.endsWith('.js')
+    ? require(configPath)
+    : content ? JSON.parse(content) : fs.readJsonSync(configPath)
 }

--- a/src/find-configuration/index.ts
+++ b/src/find-configuration/index.ts
@@ -1,1 +1,6 @@
-export {findConfiguration, findOptions, FindStrategy, defaultGetBy} from './find-configuration'
+export {
+  findConfiguration,
+  findOptions,
+  FindStrategy,
+  defaultGetBy
+} from './find-configuration'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {CreateWebpackCompiler} from './webpack'
-export {CreateBabelCompiler} from './babel'
-export {CreateMochaTester} from './mocha'
-export {CreateJestTester} from './jest'
+export { CreateWebpackCompiler } from './webpack'
+export { CreateBabelCompiler } from './babel'
+export { CreateMochaTester } from './mocha'
+export { CreateJestTester } from './jest'

--- a/src/jest/default-configuration.ts
+++ b/src/jest/default-configuration.ts
@@ -1,5 +1,5 @@
 export const defaultConfig = {
-    testRegex: "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    moduleFileExtensions: ["ts", "tsx", "jsx", "js"],
-    testPathIgnorePatterns: ["/node_modules/", "/.git/"]
+  testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  moduleFileExtensions: ['ts', 'tsx', 'jsx', 'js'],
+  testPathIgnorePatterns: ['/node_modules/', '/.git/']
 }

--- a/src/jest/index.ts
+++ b/src/jest/index.ts
@@ -1,3 +1,3 @@
-import {default as jestTester} from './jest'
-export {CreateJestTester} from './jest'
+import { default as jestTester } from './jest'
+export { CreateJestTester } from './jest'
 export default jestTester

--- a/src/jest/jest.ts
+++ b/src/jest/jest.ts
@@ -2,186 +2,178 @@ import path from 'path'
 import fs from 'fs-extra'
 import _get from 'lodash.get'
 import child_process from 'child_process'
-import {defaultConfig} from './default-configuration'
+import { defaultConfig } from './default-configuration'
 import {
-    TesterExtension,
-    API,
-    ActionTesterOptions,
-    ExtensionApiOptions,
-    Logger,
-    createPrivateRequire,
-    cleanPrivateRequire
+  TesterExtension,
+  API,
+  ActionTesterOptions,
+  ExtensionApiOptions,
+  Logger,
+  createPrivateRequire,
+  cleanPrivateRequire
 } from '../env-utils/'
-import {
-    loadPackageJsonSync,
-    fillDependencyVersion
-} from '../env-utils'
-import {FindStrategy, findConfiguration} from '../../src/find-configuration'
+import { loadPackageJsonSync, fillDependencyVersion } from '../env-utils'
+import { FindStrategy, findConfiguration } from '../../src/find-configuration'
 import { convertJestFormatToBitFormat } from './result-adapter'
 
 export default CreateJestTester()
 
-export function CreateJestTester(): TesterExtension {
-    const metaJest: TesterExtension = {
-        init: function({ api }: { api: API }) {
-            metaJest.logger = api.getLogger()
-            return {
-                write: true
-            }
-        },
+export function CreateJestTester (): TesterExtension {
+  const metaJest: TesterExtension = {
+    init: function ({ api }: { api: API }) {
+      metaJest.logger = api.getLogger()
+      return {
+        write: true
+      }
+    },
 
-        getDynamicConfig: function(info: ActionTesterOptions) {
-            let config = jestFindConfiguration(info)
-            return config.save ? config.config : {}
-        },
-        action: function(info: ActionTesterOptions) {
-            // const configFromFind = jestFindConfiguration(info)
-            // const config = _get(configFromFind, 'config.jest', configFromFind.config)
-            const directory = getDirectory(info, metaJest.logger!)
-            const resultHandler = CreateResultFileHandler(directory)
+    getDynamicConfig: function (info: ActionTesterOptions) {
+      let config = jestFindConfiguration(info)
+      return config.save ? config.config : {}
+    },
+    action: function (info: ActionTesterOptions) {
+      // const configFromFind = jestFindConfiguration(info)
+      const directory = getDirectory(info, metaJest.logger!)
+      const resultHandler = CreateResultFileHandler(directory)
 
-            const outputFile = resultHandler.preTest()
-            // const jestPath = Object.keys(require.cache).find((elem) => !!~elem.indexOf('jest-cli/bin/jest')) //path.resolve(__dirname, '../../node_modules/.bin/jest')
-            const privateRequire = createPrivateRequire(directory, 'require.resolve(pathToModule)')
+      const outputFile = resultHandler.preTest()
+      const privateRequire = createPrivateRequire(
+        directory,
+        'require.resolve(pathToModule)'
+      )
 
-            // const jestPath = require.resolve('jest/bin/jest')
-            const jestPath = privateRequire('jest/bin/jest')
-            cleanPrivateRequire(directory)
-            const testFilePath = info.testFiles.map((f)=>f.path)
-            const oldDir = process.cwd()
-            process.chdir(directory)
-            child_process.execSync(`${jestPath} --json ${testFilePath.join(' ')} > ${outputFile}`, {stdio:[]})
-            process.chdir(oldDir)
-            const results = resultHandler.getResults()
-            const normalizedResults = convertJestFormatToBitFormat(results)
-            resultHandler.postTest()
-            return Promise.resolve(normalizedResults)
+      // const jestPath = require.resolve('jest/bin/jest')
+      const jestPath = privateRequire('jest/bin/jest')
+      cleanPrivateRequire(directory)
+      const testFilePath = info.testFiles.map(f => f.path)
+      const oldDir = process.cwd()
+      process.chdir(directory)
+      child_process.execSync(
+        `${jestPath} --json ${testFilePath.join(' ')} > ${outputFile}`,
+        { stdio: [] }
+      )
+      process.chdir(oldDir)
+      const results = resultHandler.getResults()
+      const normalizedResults = convertJestFormatToBitFormat(results)
+      resultHandler.postTest()
+      return Promise.resolve(normalizedResults)
+    },
+    getDynamicPackageDependencies: function (info: ExtensionApiOptions) {
+      let packages = {}
+      const packageJson = loadPackageJsonSync(
+        info.context.componentDir,
+        info.context.workspaceDir
+      )
+      if (!packageJson) {
+        metaJest.logger!.log('Could not find package.json.')
+        return packages
+      }
 
+      const configFromFind = jestFindConfiguration(info)
+      const config = _get(configFromFind, 'config.jest', configFromFind.config)
 
-        },
-        getDynamicPackageDependencies: function(info: ExtensionApiOptions) {
-            let packages = {}
-            const packageJson = loadPackageJsonSync(
-                info.context.componentDir,
-                info.context.workspaceDir
-            )
-            if (!packageJson) {
-                metaJest.logger!.log('Could not find package.json.')
-                return packages
-            }
-
-            const configFromFind = jestFindConfiguration(info)
-            const config = _get(configFromFind, 'config.jest', configFromFind.config)
-
-            const paths = [
-                'transform',
-                'preset',
-                'prettierPath',
-                'moduleNameMapper',
-                'snapshotSerializers'
-            ]
-            jestFindDynamicDependencies(config, paths, packageJson, packages)
-            return packages
-        }
+      const paths = [
+        'transform',
+        'preset',
+        'prettierPath',
+        'moduleNameMapper',
+        'snapshotSerializers'
+      ]
+      jestFindDynamicDependencies(config, paths, packageJson, packages)
+      return packages
     }
-    return metaJest
+  }
+  return metaJest
 }
-function parseAndFillDependencyVersion(
-    packageJson: object,
-    value: string,
-    toFill: { [k: string]: string }
+function parseAndFillDependencyVersion (
+  packageJson: object,
+  value: string,
+  toFill: { [k: string]: string }
 ) {
-    if (!!~value.indexOf('node_modules')) {
-        const valueParts = value.split('/')
-        const packageIndex = valueParts.indexOf('node_modules')
-        if (packageIndex !== valueParts.length - 1) {
-            fillDependencyVersion(
-                packageJson,
-                valueParts[packageIndex + 1],
-                toFill
-            )
-        }
-        return
+  if (~value.indexOf('node_modules')) {
+    const valueParts = value.split('/')
+    const packageIndex = valueParts.indexOf('node_modules')
+    if (packageIndex !== valueParts.length - 1) {
+      fillDependencyVersion(packageJson, valueParts[packageIndex + 1], toFill)
     }
-    fillDependencyVersion(packageJson, value, toFill)
+    return
+  }
+  fillDependencyVersion(packageJson, value, toFill)
 }
 
-function jestFindDynamicDependencies(
-    config: any,
-    paths: Array<string>,
-    packageJson: object,
-    toFill: { [k: string]: string }) {
-    paths.forEach(function(path: string) {
-        const value = _get(config, path)
-        if (!value) {
-            return
-        }
-        if (typeof value === 'string') {
-            parseAndFillDependencyVersion(packageJson, value, toFill)
-        } else if (value instanceof Array) {
-            value.forEach(function(item: string) {
-                parseAndFillDependencyVersion(packageJson, item, toFill)
-            })
-        } else if (typeof value === 'object') {
-            Object.keys(value).forEach(function(key) {
-                const internalValue = value[key]
-                parseAndFillDependencyVersion(
-                    packageJson,
-                    internalValue,
-                    toFill
-                )
-            })
-        }
-    })
-}
-
-function CreateResultFileHandler(directory: string) {
-    const resultFileName = 'jestResults.json'
-    let outputFile = ''
-    let bitTmpPath = ''
-    return {
-        preTest: function() {
-            bitTmpPath = path.resolve(directory, '.bitTmp')
-            outputFile = path.resolve(directory, '.bitTmp', resultFileName)
-            !fs.existsSync(bitTmpPath) && fs.mkdirpSync(bitTmpPath)
-            return outputFile
-        },
-        postTest: function() {
-            fs.existsSync(outputFile) && fs.unlinkSync(outputFile)
-            fs.emptyDir(bitTmpPath) && fs.removeSync(bitTmpPath)
-        },
-        getResults: function() {
-            let result = null
-            if (!fs.existsSync(outputFile)) {
-                throw new Error('can not find ' + resultFileName)
-            }
-            try {
-                result = fs.readJsonSync(outputFile)
-            } catch (e) {
-                throw new Error('result not a valid json')
-            }
-            return result
-        }
+function jestFindDynamicDependencies (
+  config: any,
+  paths: Array<string>,
+  packageJson: object,
+  toFill: { [k: string]: string }
+) {
+  paths.forEach(function (path: string) {
+    const value = _get(config, path)
+    if (!value) {
+      return
     }
-}
-
-function getDirectory(info: ActionTesterOptions, logger: Logger) {
-    const directory =
-        _get(info, 'context.workspaceDir') ||
-        _get(info, 'context.componentDir') ||
-        _get(info, 'context.testFiles[0].path')
-    if (!directory) {
-        logger.error('Could not find test directory')
-        throw new Error('Could not find test directory')
+    if (typeof value === 'string') {
+      parseAndFillDependencyVersion(packageJson, value, toFill)
+    } else if (value instanceof Array) {
+      value.forEach(function (item: string) {
+        parseAndFillDependencyVersion(packageJson, item, toFill)
+      })
+    } else if (typeof value === 'object') {
+      Object.keys(value).forEach(function (key) {
+        const internalValue = value[key]
+        parseAndFillDependencyVersion(packageJson, internalValue, toFill)
+      })
     }
-    return directory
+  })
 }
 
-export function jestFindConfiguration(info:ExtensionApiOptions){
-    return findConfiguration(info, {
-        [FindStrategy.pjKeyName]: 'jest',
-        [FindStrategy.fileName]: 'jest.config.js',
-        [FindStrategy.default]: defaultConfig,
-        [FindStrategy.defaultFilePaths]: ['./jest.config.js'],
-    })
+function CreateResultFileHandler (directory: string) {
+  const resultFileName = 'jestResults.json'
+  let outputFile = ''
+  let bitTmpPath = ''
+  return {
+    preTest: function () {
+      bitTmpPath = path.resolve(directory, '.bitTmp')
+      outputFile = path.resolve(directory, '.bitTmp', resultFileName)
+      !fs.existsSync(bitTmpPath) && fs.mkdirpSync(bitTmpPath)
+      return outputFile
+    },
+    postTest: function () {
+      fs.existsSync(outputFile) && fs.unlinkSync(outputFile)
+      fs.emptyDir(bitTmpPath) && fs.removeSync(bitTmpPath)
+    },
+    getResults: function () {
+      let result = null
+      if (!fs.existsSync(outputFile)) {
+        throw new Error('can not find ' + resultFileName)
+      }
+      try {
+        result = fs.readJsonSync(outputFile)
+      } catch (e) {
+        throw new Error('result not a valid json')
+      }
+      return result
+    }
+  }
+}
+
+function getDirectory (info: ActionTesterOptions, logger: Logger) {
+  const directory =
+    _get(info, 'context.workspaceDir') ||
+    _get(info, 'context.componentDir') ||
+    _get(info, 'context.testFiles[0].path')
+  if (!directory) {
+    logger.error('Could not find test directory')
+    throw new Error('Could not find test directory')
+  }
+  return directory
+}
+
+export function jestFindConfiguration (info: ExtensionApiOptions) {
+  return findConfiguration(info, {
+    [FindStrategy.pjKeyName]: 'jest',
+    [FindStrategy.fileName]: 'jest.config.js',
+    [FindStrategy.default]: defaultConfig,
+    [FindStrategy.defaultFilePaths]: ['./jest.config.js']
+  })
 }

--- a/src/jest/result-adapter.ts
+++ b/src/jest/result-adapter.ts
@@ -1,57 +1,59 @@
 import _isEmpty from 'lodash.isempty'
 
-export function convertJestFormatToBitFormat(results: any) {
-    const testResults = results.testResults
-    let failures: Array<any> = []
-    let testProps: Array<any> = []
-    const res = testResults.map((test: any) => {
-        const duration = test.endTime - test.startTime
-        if (_isEmpty(test.assertionResults)) {
-            failures.push({
-                title: 'Test suite failed to run',
-                err: {
-                    message: test.message
-                },
-                duration: duration
-            })
-        } else {
-            testProps = test.assertionResults.map((assertionRes: any) => {
-                const title = assertionRes.title
-                const pass = assertionRes.status === 'passed' ? true : false
-                const err = !pass ? {
-                        message: assertionRes.failureMessages[0],
-                        stack: assertionRes.failureMessages[0]
-                    } :
-                    undefined
-                if (err)
-                    return {
-                        title,
-                        pass,
-                        duration,
-                        err
-                    }
-                return {
-                    title,
-                    pass,
-                    duration
-                }
-            })
-        }
-        const StatsProps = {
-            start: test.startTime,
-            end: test.endTime,
-            duration: duration
-        }
-        const pass = test.status === 'passed' ? true : false
-        return {
-            tests: testProps,
-            stats: StatsProps,
+export function convertJestFormatToBitFormat (results: any) {
+  const testResults = results.testResults
+  let failures: Array<any> = []
+  let testProps: Array<any> = []
+  const res = testResults.map((test: any) => {
+    const duration = test.endTime - test.startTime
+    if (_isEmpty(test.assertionResults)) {
+      failures.push({
+        title: 'Test suite failed to run',
+        err: {
+          message: test.message
+        },
+        duration: duration
+      })
+    } else {
+      testProps = test.assertionResults.map((assertionRes: any) => {
+        const title = assertionRes.title
+        const pass = assertionRes.status === 'passed'
+        const err = !pass
+          ? {
+            message: assertionRes.failureMessages[0],
+            stack: assertionRes.failureMessages[0]
+          }
+          : undefined
+        if (err) {
+          return {
+            title,
             pass,
-            failures,
-            specPath: test.name
+            duration,
+            err
+          }
         }
-    })
-    return res
+        return {
+          title,
+          pass,
+          duration
+        }
+      })
+    }
+    const StatsProps = {
+      start: test.startTime,
+      end: test.endTime,
+      duration: duration
+    }
+    const pass = test.status === 'passed'
+    return {
+      tests: testProps,
+      stats: StatsProps,
+      pass,
+      failures,
+      specPath: test.name
+    }
+  })
+  return res
 }
 
 export default convertJestFormatToBitFormat

--- a/src/mocha/base-reporter.ts
+++ b/src/mocha/base-reporter.ts
@@ -1,64 +1,64 @@
-import {Runner , Stats, Test} from 'mocha'
+import { Runner, Stats, Test } from 'mocha'
 import _get from 'lodash.get'
 
-export function Base(this:any, runner:Runner) {
-    // let stats = getEmptyStats()
-    const failures:Array<Test> = this.failures = []
+export function Base (this: any, runner: Runner) {
+  // let stats = getEmptyStats()
+  const failures: Array<Test> = (this.failures = [])
 
-    if (!runner) {
-        return
+  if (!runner) {
+    return
+  }
+  this.runner = runner
+
+  runner.stats = getEmptyStats()
+
+  runner.on('start', function () {
+    runner.stats!.start = new Date()
+  })
+
+  runner.on('suite', function (suite) {
+    runner.stats!.suites = runner.stats!.suites || 0
+    suite.root || runner.stats!.suites++
+  })
+
+  runner.on('test end', function () {
+    runner.stats!.tests = runner.stats!.tests || 0
+    runner.stats!.tests++
+  })
+
+  runner.on('pass', function (test) {
+    runner.stats!.passes = runner.stats!.passes || 0
+    if (!test.duration) {
+      test.speed = undefined
+    } else if (test.duration > test.slow()) {
+      test.speed = 'slow'
+    } else if (test.duration > test.slow() / 2) {
+      test.speed = 'medium'
+    } else {
+      test.speed = 'fast'
     }
-    this.runner = runner
 
-    runner.stats = getEmptyStats()
+    runner.stats!.passes++
+  })
 
-    runner.on('start', function () {
-        runner.stats!.start = new Date()
-    })
+  runner.on('fail', function (test, err: Error) {
+    runner.stats!.failures = runner.stats!.failures || 0
+    runner.stats!.failures++
+    test.err = err
+    failures.push(test)
+  })
 
-    runner.on('suite', function (suite) {
-        runner.stats!.suites = runner.stats!.suites || 0
-        suite.root || runner.stats!.suites++
-    })
+  runner.on('suite end', function () {
+    runner.stats!.end = new Date()
+    runner.stats!.duration =
+      new Date().getMilliseconds() - (_get(runner, 'stats.start', 0) as number)
+  })
 
-    runner.on('test end', function () {
-        runner.stats!.tests = runner.stats!.tests || 0
-        runner.stats!.tests++
-    })
-
-    runner.on('pass', function (test) {
-        runner.stats!.passes = runner.stats!.passes || 0
-        if (!test.duration) {
-            test.speed = undefined
-        } else if (test.duration > test.slow()) {
-            test.speed = 'slow'
-        } else if (test.duration > test.slow() / 2) {
-            test.speed = 'medium'
-        } else {
-            test.speed = 'fast'
-        }
-
-        runner.stats!.passes++
-    })
-
-    runner.on('fail', function (test, err:Error) {
-        runner.stats!.failures = runner.stats!.failures || 0
-        runner.stats!.failures++
-        test.err = err
-        failures.push(test)
-    })
-
-    runner.on('suite end', function () {
-        runner.stats!.end = new Date()
-        runner.stats!.duration = new Date().getMilliseconds() - (_get(runner, 'stats.start' , 0) as number)
-    })
-
-    runner.on('pending', function () {
-        runner.stats!.pending++
-    })
-
+  runner.on('pending', function () {
+    runner.stats!.pending++
+  })
 }
 
-export function getEmptyStats() {
-    return ({ suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 } as Stats)
+export function getEmptyStats () {
+  return { suites: 0, tests: 0, passes: 0, pending: 0, failures: 0 } as Stats
 }

--- a/src/mocha/index.ts
+++ b/src/mocha/index.ts
@@ -1,3 +1,3 @@
-import {default as mochaTester} from './mocha'
-export {CreateMochaTester} from './mocha'
+import { default as mochaTester } from './mocha'
+export { CreateMochaTester } from './mocha'
 export default mochaTester

--- a/src/mocha/json-reporter.ts
+++ b/src/mocha/json-reporter.ts
@@ -1,6 +1,6 @@
-import { Runner, Test ,Reporter} from 'mocha'
-import {Base, getEmptyStats} from './base-reporter'
-import {TestResult} from '../env-utils/types'
+import { Runner, Test, Reporter } from 'mocha'
+import { Base, getEmptyStats } from './base-reporter'
+import { TestResult } from '../env-utils/types'
 import _get from 'lodash.get'
 /***
  * Initialize a new `JSON` reporter.
@@ -8,85 +8,85 @@ import _get from 'lodash.get'
  * @api public
  * @param {Runner} runner
  */
-export function JSONReporter(this:Reporter, runner: Runner) {
-    Base.call(this, runner)
+export function JSONReporter (this: Reporter, runner: Runner) {
+  Base.call(this, runner)
 
-    const flattenResult:{[k:string]:Array<any>} = {}
+  const flattenResult: { [k: string]: Array<any> } = {}
 
-    let tests: Array<Test>
-    let pending: Array<Test>
-    let failures: Array<Test>
-    let passes: Array<Test>
+  let tests: Array<Test>
+  let pending: Array<Test>
+  let failures: Array<Test>
+  let passes: Array<Test>
 
-    function init () {
-        tests = []
-        pending = []
-        failures = []
-        passes = []
+  function init () {
+    tests = []
+    pending = []
+    failures = []
+    passes = []
+  }
+  init()
+  runner.on('test end', function (test) {
+    tests.push(test)
+  })
+
+  runner.on('pass', function (test) {
+    passes.push(test)
+  })
+
+  runner.on('fail', function (test) {
+    failures.push(test)
+  })
+
+  runner.on('pending', function (test) {
+    pending.push(test)
+  })
+
+  runner.on('suite end', function () {
+    if (_get(flattenResult, 'runner.currentRunnable.file')) {
+      throw new Error('Could not find test suite original runner')
     }
+    if (
+      !tests.length &&
+      !pending.length &&
+      !failures.length &&
+      !passes.length
+    ) {
+      return
+    }
+    const obj = {
+      stats: runner.stats,
+      tests: tests.map(clean),
+      pending: pending.map(clean),
+      failures: failures.map(clean),
+      passes: passes.map(clean)
+    }
+
+    Array.isArray(flattenResult[runner.currentRunnable!.file!])
+      ? flattenResult[runner.currentRunnable!.file!].push(obj)
+      : (flattenResult[runner.currentRunnable!.file!] = [obj])
+
     init()
-    runner.on('test end', function (test) {
-        tests.push(test)
-    })
+    runner.stats = getEmptyStats()
+  })
 
-    runner.on('pass', function (test) {
-        passes.push(test)
-    })
-
-    runner.on('fail', function (test) {
-        failures.push(test)
-    })
-
-    runner.on('pending', function (test) {
-        pending.push(test)
-    })
-
-    runner.on('suite end', function () {
-        if (_get(flattenResult, 'runner.currentRunnable.file')){
-            throw new Error('Could not find test suite original runner')
-        }
-        if (!tests.length    &&
-            !pending.length  &&
-            !failures.length &&
-            !passes.length){
-                return;
-        }
-        const obj = {
-            stats: runner.stats,
-            tests: tests.map(clean),
-            pending: pending.map(clean),
-            failures: failures.map(clean),
-            passes: passes.map(clean)
-        }
-
-        Array.isArray(flattenResult[runner.currentRunnable!.file!]) ?
-            flattenResult[runner.currentRunnable!.file!].push(obj) :
-            flattenResult[runner.currentRunnable!.file!] = [obj]
-
-        init()
-        runner.stats = getEmptyStats()
-    })
-
-    runner.on('end', function (this:Runner) {
-        (this as any).testResults = flattenResult
-    })
-
+  runner.on('end', function (this: Runner) {
+    (this as any).testResults = flattenResult
+  })
 }
 
-
-function clean(test: Test):TestResult {
-    return {
-        title: test.title,
-        fullTitle: test.fullTitle(),
-        duration: test.duration,
-        currentRetry: (test as any).currentRetry(),
-        err: errorJSON(test.err || {})
-    }
+function clean (test: Test): TestResult {
+  return {
+    title: test.title,
+    fullTitle: test.fullTitle(),
+    duration: test.duration,
+    currentRetry: (test as any).currentRetry(),
+    err: errorJSON(test.err || {})
+  }
 }
-function errorJSON(err: Error | {}) {
-    const res:{[key:string]:string} = {}
-    Object.getOwnPropertyNames(err).forEach(function (key) {
-        res[key] = (err as any)[key]
-    }, err)
-    return res
+function errorJSON (err: Error | {}) {
+  const res: { [key: string]: string } = {}
+  Object.getOwnPropertyNames(err).forEach(function (key) {
+    res[key] = (err as any)[key]
+  }, err)
+  return res
 }

--- a/src/mocha/mocha.ts
+++ b/src/mocha/mocha.ts
@@ -1,131 +1,148 @@
-import { TesterExtension, ExtensionApiOptions, API, ActionTesterOptions } from '../env-utils/types'
-import { loadPackageJsonSync, fillDependencyVersion } from '../env-utils'
-import { FindStrategy, findConfiguration} from '../../src/find-configuration'
+import {
+  TesterExtension,
+  ExtensionApiOptions,
+  API,
+  ActionTesterOptions
+} from '../env-utils/types'
+import {
+    loadPackageJsonSync,
+    fillDependencyVersion,
+    createPrivateRequire,
+    cleanPrivateRequire
+} from '../env-utils'
+import { FindStrategy, findConfiguration } from '../../src/find-configuration'
 import { JSONReporter } from './json-reporter'
-import {createPrivateRequire, cleanPrivateRequire} from '../env-utils'
-import Mocha, {Test} from 'mocha'
+import Mocha, { Test } from 'mocha'
 import _get from 'lodash.get'
 import path from 'path'
 
-export function CreateMochaTester(): TesterExtension {
-    const metaMocha: TesterExtension = {
-        init: function ({ api }: { api: API }) {
-            metaMocha.logger = api.getLogger()
-            return {
-                write:false
-            }
-        },
-        getDynamicConfig: function (info: ActionTesterOptions) {
-            let config = mochaFindConfiguration(info)
-            return config.save ? config.config : info.rawConfig
-        },
-        action: function (info: ActionTesterOptions) {
-            const correctFolder = info.context.componentDir || info.context.workspaceDir
-            const privateRequire = createPrivateRequire(correctFolder)
-            _get(info, 'dynamicConfig.require', []).forEach(function(toRequire:string){
-                privateRequire(toRequire)
-            })
-            _get(info, 'dynamicConfig.filesRequire', []).forEach(function(toRequire:string){
-                require(path.resolve(correctFolder, toRequire))
-            })
-            cleanPrivateRequire(correctFolder)
-            const configFromFind = mochaFindConfiguration(info)
-            const config = _get(configFromFind, 'config.mocha', configFromFind.config)
-            Object.assign(config, { reporter: (JSONReporter as any) })
-            try {
-                return new Promise((resolve) => {
-                    const mocha = new Mocha(config)
+export function CreateMochaTester (): TesterExtension {
+  const metaMocha: TesterExtension = {
+    init: function ({ api }: { api: API }) {
+      metaMocha.logger = api.getLogger()
+      return {
+        write: false
+      }
+    },
+    getDynamicConfig: function (info: ActionTesterOptions) {
+      let config = mochaFindConfiguration(info)
+      return config.save ? config.config : info.rawConfig
+    },
+    action: function (info: ActionTesterOptions) {
+      const correctFolder =
+        info.context.componentDir || info.context.workspaceDir
+      const privateRequire = createPrivateRequire(correctFolder)
+      _get(info, 'dynamicConfig.require', []).forEach(function (
+        toRequire: string
+      ) {
+        privateRequire(toRequire)
+      })
+      _get(info, 'dynamicConfig.filesRequire', []).forEach(function (
+        toRequire: string
+      ) {
+        require(path.resolve(correctFolder, toRequire))
+      })
+      cleanPrivateRequire(correctFolder)
+      const configFromFind = mochaFindConfiguration(info)
+      const config = _get(configFromFind, 'config.mocha', configFromFind.config)
+      Object.assign(config, { reporter: JSONReporter as any })
+      try {
+        return new Promise(resolve => {
+          const mocha = new Mocha(config)
 
-                    info.testFiles.forEach((testFile) => {
-                        mocha.addFile(testFile.path)
-                    })
-                    mocha.run()
-                    .on('end', function (this: { testResults: any }) {
-                        const results = this.testResults
-                        const rawResults = ([]).concat.apply([], Object.keys(results).map(function (item) {
-                            return results[item].map(function (describerResult:any) {
-                                return normalizeResults(describerResult, item)
-                            })
-
-                        }) )
-                        resolve(rawResults)
-                    })
+          info.testFiles.forEach(testFile => {
+            mocha.addFile(testFile.path)
+          })
+          mocha.run().on('end', function (this: { testResults: any }) {
+            const results = this.testResults
+            const rawResults = [].concat.apply(
+              [],
+              Object.keys(results).map(function (item) {
+                return results[item].map(function (describerResult: any) {
+                  return normalizeResults(describerResult, item)
                 })
-            } catch (e) {
-                throw e
-            }
-        },
-        getDynamicPackageDependencies: function (info: ExtensionApiOptions) {
-            // console.log('getDynamicPackageDependencies')
-            const packages = {}
-            const packageJson = loadPackageJsonSync(info.context.componentDir, info.context.workspaceDir)
-            if (!packageJson) {
-                metaMocha.logger!.error('Could not find package.json.')
-                return packages
-            }
-            _get(info, 'dynamicConfig.require', []).forEach(function (mochaRequire: string) {
-                const requireParts = mochaRequire.split('/')
-                fillDependencyVersion(packageJson, requireParts[0], packages)
-            })
-            return packages
-        }
+              })
+            )
+            resolve(rawResults)
+          })
+        })
+      } catch (e) {
+        throw e
+      }
+    },
+    getDynamicPackageDependencies: function (info: ExtensionApiOptions) {
+      // console.log('getDynamicPackageDependencies')
+      const packages = {}
+      const packageJson = loadPackageJsonSync(
+        info.context.componentDir,
+        info.context.workspaceDir
+      )
+      if (!packageJson) {
+        metaMocha.logger!.error('Could not find package.json.')
+        return packages
+      }
+      _get(info, 'dynamicConfig.require', []).forEach(function (
+        mochaRequire: string
+      ) {
+        const requireParts = mochaRequire.split('/')
+        fillDependencyVersion(packageJson, requireParts[0], packages)
+      })
+      return packages
     }
-    return metaMocha
+  }
+  return metaMocha
 }
 
 const isEmptyObject = (obj: object) => Object.keys(obj).length === 0
 
-
-function normalizeResults(mochaJsonResults: any, file: string) {
-    function normalizeError(err: Error) {
-        return {
-            message: err.message,
-            stack: err.stack
-        }
-    }
-
-    function normalizeStats(stats: { start: number, end: number }) {
-        return {
-            start: stats.start,
-            end: stats.end
-        }
-    }
-
-    function normalizeTest(test: Test) {
-        const isError = test.err && !isEmptyObject(test.err)
-        return ({
-            title: test.fullTitle,
-            pass: !isError,
-            err: isError && test.err ? normalizeError(test.err) : null,
-            duration: test.duration
-        })
-    }
-
-    function normalizeFailure(failure: Test) {
-        const isError = failure.err && !isEmptyObject(failure.err)
-        return ({
-            title: failure.fullTitle,
-            err: failure.err && isError ? normalizeError(failure.err) : null,
-            duration: failure.duration
-        })
-    }
-
+function normalizeResults (mochaJsonResults: any, file: string) {
+  function normalizeError (err: Error) {
     return {
-        tests: mochaJsonResults.tests.map(normalizeTest),
-        stats: normalizeStats(mochaJsonResults.stats),
-        failures: mochaJsonResults.failures.map(normalizeFailure),
-        pass: mochaJsonResults.failures.length === 0,
-        specPath: file
+      message: err.message,
+      stack: err.stack
     }
+  }
+
+  function normalizeStats (stats: { start: number; end: number }) {
+    return {
+      start: stats.start,
+      end: stats.end
+    }
+  }
+
+  function normalizeTest (test: Test) {
+    const isError = test.err && !isEmptyObject(test.err)
+    return {
+      title: test.fullTitle,
+      pass: !isError,
+      err: isError && test.err ? normalizeError(test.err) : null,
+      duration: test.duration
+    }
+  }
+
+  function normalizeFailure (failure: Test) {
+    const isError = failure.err && !isEmptyObject(failure.err)
+    return {
+      title: failure.fullTitle,
+      err: failure.err && isError ? normalizeError(failure.err) : null,
+      duration: failure.duration
+    }
+  }
+
+  return {
+    tests: mochaJsonResults.tests.map(normalizeTest),
+    stats: normalizeStats(mochaJsonResults.stats),
+    failures: mochaJsonResults.failures.map(normalizeFailure),
+    pass: mochaJsonResults.failures.length === 0,
+    specPath: file
+  }
 }
 
-
-export function mochaFindConfiguration(info:ExtensionApiOptions){
-    return findConfiguration(info, {
-        [FindStrategy.pjKeyName]: 'mocha',
-        [FindStrategy.default]: {}
-    })
+export function mochaFindConfiguration (info: ExtensionApiOptions) {
+  return findConfiguration(info, {
+    [FindStrategy.pjKeyName]: 'mocha',
+    [FindStrategy.default]: {}
+  })
 }
-
 
 export default CreateMochaTester()

--- a/src/webpack/default-config.ts
+++ b/src/webpack/default-config.ts
@@ -1,82 +1,95 @@
-const babelPresetEs2015 = require('babel-preset-es2015');
-const babelPresetReact = require('babel-preset-react');
-const stage0 = require('babel-preset-stage-0');
+const babelPresetEs2015 = require('babel-preset-es2015')
+const babelPresetReact = require('babel-preset-react')
+const stage0 = require('babel-preset-stage-0')
 
-//indirect
-require('babel-loader');
-require('babel-core');
-require('style-loader');
-require('css-loader');
-require('sass-loader');
-require('node-sass');
-require('json-loader');
-require('url-loader');
+// indirect
+require('babel-loader')
+require('babel-core')
+require('style-loader')
+require('css-loader')
+require('sass-loader')
+require('node-sass')
+require('json-loader')
+require('url-loader')
 
-const nodeExternals = require('webpack-node-externals');
-const PACKAGE_TYPE = 'umd';
+const nodeExternals = require('webpack-node-externals')
+const PACKAGE_TYPE = 'umd'
 
 const configure = () => {
-    return {
-        output: {
-            filename: '[name].bundle.js',
-            libraryTarget: PACKAGE_TYPE,
+  return {
+    output: {
+      filename: '[name].bundle.js',
+      libraryTarget: PACKAGE_TYPE
+    },
+    module: {
+      rules: [
+        {
+          test: /.(js|jsx)$/,
+          loader: 'babel-loader',
+          options: {
+            babelrc: false,
+            presets: [babelPresetReact, babelPresetEs2015, stage0]
+          }
         },
-        module: {
-            rules: [{
-                test: /.(js|jsx)$/,
-                loader: 'babel-loader',
-                options: {
-                    babelrc: false,
-                    presets:[babelPresetReact, babelPresetEs2015, stage0 ]
-                }
-            }, {
-                test: /\.css$/,
-                use: [{
-                    loader: "style-loader" // creates style nodes from JS strings
-                }, {
-                    loader: "css-loader", // translates CSS into CommonJS
-                    options: {
-                        import: true,
-                        modules: true,
-                    }
-                }]
-            }, {
-                test: /\.scss$/,
-                use: [{
-                    loader: "style-loader" // creates style nodes from JS strings
-                }, {
-                    loader: "css-loader", // translates CSS into CommonJS
-                    options: {
-                        import: true,
-                        modules: true,
-                    }
-                }, {
-                    loader: "sass-loader" // compiles Sass to CSS
-                }]
-            },
-            // JSON is not enabled by default in Webpack but both Node and Browserify
-            // allow it implicitly so we also enable it.
+        {
+          test: /\.css$/,
+          use: [
             {
-                test: /\.json$/,
-                loader: 'json-loader'
+              loader: 'style-loader' // creates style nodes from JS strings
             },
-
-            // "url" loader works just like "file" loader but it also embeds
-            // assets smaller than specified size as data URLs to avoid requests.
             {
-                test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
-                loader: 'url',
-                query: {
-                    limit: 10000,
-                    name: 'static/media/[name].[hash:8].[ext]'
-                }
-            }]
+              loader: 'css-loader', // translates CSS into CommonJS
+              options: {
+                import: true,
+                modules: true
+              }
+            }
+          ]
+        },
+        {
+          test: /\.scss$/,
+          use: [
+            {
+              loader: 'style-loader' // creates style nodes from JS strings
+            },
+            {
+              loader: 'css-loader', // translates CSS into CommonJS
+              options: {
+                import: true,
+                modules: true
+              }
+            },
+            {
+              loader: 'sass-loader' // compiles Sass to CSS
+            }
+          ]
+        },
+        // JSON is not enabled by default in Webpack but
+        // both Node and Browserify allow it implicitly so we also enable it.
+        {
+          test: /\.json$/,
+          loader: 'json-loader'
         },
 
-        externals: [ nodeExternals({
-            importType: PACKAGE_TYPE
-        }) ]
-    };
+        // "url" loader works just like "file" loader but it also embeds
+        // assets smaller than specified size as data URLs to avoid requests.
+        {
+          test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
+          loader: 'url',
+          query: {
+            limit: 10000,
+            name: 'static/media/[name].[hash:8].[ext]'
+          }
+        }
+      ]
+    },
+
+    externals: [
+      nodeExternals({
+        importType: PACKAGE_TYPE
+      })
+    ]
+  }
 }
 
-export default configure();
+export default configure()

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -1,3 +1,3 @@
-import {default as webpackCompiler} from './webpack'
-export {CreateWebpackCompiler} from './webpack'
+import { default as webpackCompiler } from './webpack'
+export { CreateWebpackCompiler } from './webpack'
 export default webpackCompiler

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -2,126 +2,168 @@ import webpack from 'webpack'
 import MemoryFS from 'memory-fs'
 import Vinyl from 'vinyl'
 import _get from 'lodash.get'
-import {CompilerExtension, ExtensionApiOptions, API ,Logger} from '../env-utils/types'
-import {loadPackageJsonSync, fillDependencyVersion, findByName} from '../env-utils'
-import {findConfiguration, FindStrategy } from '../find-configuration'
-import {getBabelDynamicPackageDependencies} from '../babel-dependencies'
+import {
+  CompilerExtension,
+  ExtensionApiOptions,
+  API,
+  Logger
+} from '../env-utils/types'
+import {
+  loadPackageJsonSync,
+  fillDependencyVersion,
+  findByName
+} from '../env-utils'
+import { findConfiguration, FindStrategy } from '../find-configuration'
+import { getBabelDynamicPackageDependencies } from '../babel-dependencies'
 import DefaulftWebapckConfig from './default-config'
 
-export function CreateWebpackCompiler(mainConfigName = 'webpack.config.js'):CompilerExtension {
-    const metaWebpack: CompilerExtension = {
-        init: function({ api }:{api:API}) {
-            metaWebpack.logger = api.getLogger()
-            return { write: true }
-        },
-        getDynamicConfig: function(info: ExtensionApiOptions) {
-            let config = webpackFindConfiguration(info, mainConfigName)
-            return config.save ? config.config : {}
-        },
-        action: function(info: ExtensionApiOptions) {
-            // const configuration = require(findByName(info.configFiles, mainConfigName).path)
-            const fromFind = webpackFindConfiguration(info, mainConfigName)
-            const configuration = _get(fromFind, 'config.webpack', fromFind.config)
+export function CreateWebpackCompiler (
+  mainConfigName = 'webpack.config.js'
+): CompilerExtension {
+  const metaWebpack: CompilerExtension = {
+    init: function ({ api }: { api: API }) {
+      metaWebpack.logger = api.getLogger()
+      return { write: true }
+    },
+    getDynamicConfig: function (info: ExtensionApiOptions) {
+      let config = webpackFindConfiguration(info, mainConfigName)
+      return config.save ? config.config : {}
+    },
+    action: function (info: ExtensionApiOptions) {
+      const fromFind = webpackFindConfiguration(info, mainConfigName)
+      const configuration = _get(fromFind, 'config.webpack', fromFind.config)
 
-            adjustConfigurationIfNeeded(configuration, info.context.componentObject.mainFile, metaWebpack.logger!)
-            const compiler = webpack(configuration)
-            const fs = new MemoryFS()
-            compiler.outputFileSystem = (fs as any)
-            return (new Promise(function (resolve, reject) {
-                return compiler.run(function (err, stats) {
-                    const compilation = (stats as any).compilation
-                    if (err || compilation.errors.length > 0) {
-                        metaWebpack.logger!.log(err || compilation.errors)
-                        reject(err ? {errors:[err]}: {errors:compilation.errors})
-                        return
-                    }
-                    resolve(compilation.assets)
-                })
-            }))
-            .then(function(assets:any) {
-                return {
-                    files:Object.keys(assets).map((name)=>{
-                        return new Vinyl({
-                            base: info.context.rootDistDir,
-                            baseName: name,
-                            path: assets[name].existsAt,
-                            contents: Buffer.from(assets[name]._value || assets[name].children[0]._value)
-                        })
-                    })
-                }
-            })
-        },
-        getDynamicPackageDependencies: function(info: ExtensionApiOptions, babelConfigName = '.babelrc') {
-
-            const packages: { [key: string]: string } = {}
-            const configFile = findByName(info.configFiles, mainConfigName)
-            const config = require(configFile.path)
-            const packageJson = loadPackageJsonSync(info.context.componentDir, info.context.workspaceDir)
-
-            if (!packageJson) {
-                metaWebpack.logger!.log('Could not find package.json.')
-                return packages
-            }
-
-            function handleLoader(packageJson: object, name: string, toFill: {[k:string]:string}){
-                let babelResults = {}
-                if(name === 'babel-loader'){
-                    babelResults = getBabelDynamicPackageDependencies(metaWebpack.logger!, babelConfigName)(info)
-                }
-
-                fillDependencyVersion(packageJson, name, toFill)
-                Object.assign(toFill, babelResults)
-            }
-            _get(config, 'module.rules', []).forEach(function (rule: { use?: string, loader?: string }) {
-                if (Array.isArray(rule.use)) {
-                    rule.use.forEach(function (internalUse) {
-                        handleLoader(packageJson, internalUse.loader, packages)
-                    })
-                }
-
-                if (rule.use && typeof rule.use === 'string') {
-                    handleLoader(packageJson, rule.use, packages)
-                }
-
-                if (rule.loader && typeof rule.loader === 'string') {
-                    handleLoader(packageJson, rule.loader, packages)
-                }
-            })
-            return packages
-        }
-    }
-    return metaWebpack
-}
-
-
-
-function adjustConfigurationIfNeeded(configuration:any, mainFile:string, _logger:Logger){
-    if (typeof configuration.entry === 'object' && Object.keys(configuration.entry).length > 1){
-        let correctEntry:{[x:string]:string} = {}
-        Object.keys(configuration.entry).forEach(function(entry) {
-            const entryNamNoEnding = mainFile.split('.').slice(0, -1).join('.')
-            if (configuration.entry[entry].endsWith(mainFile) ||
-                configuration.entry[entry].endsWith(entryNamNoEnding)){
-                correctEntry[entry] = configuration.entry[entry]
-            } else if(entry === 'test' || entry.endsWith('_test')) {
-                correctEntry[entry] = configuration.entry[entry]
-            }
+      adjustConfigurationIfNeeded(
+        configuration,
+        info.context.componentObject.mainFile,
+        metaWebpack.logger!
+      )
+      const compiler = webpack(configuration)
+      const fs = new MemoryFS()
+      compiler.outputFileSystem = fs as any
+      return new Promise(function (resolve, reject) {
+        return compiler.run(function (err, stats) {
+          const compilation = (stats as any).compilation
+          if (err || compilation.errors.length > 0) {
+            metaWebpack.logger!.log(err || compilation.errors)
+            reject(err ? { errors: [err] } : { errors: compilation.errors })
+            return
+          }
+          resolve(compilation.assets)
         })
-        configuration.entry = correctEntry
-    }
+      }).then(function (assets: any) {
+        return {
+          files: Object.keys(assets).map(name => {
+            return new Vinyl({
+              base: info.context.rootDistDir,
+              baseName: name,
+              path: assets[name].existsAt,
+              contents: Buffer.from(
+                assets[name]._value || assets[name].children[0]._value
+              )
+            })
+          })
+        }
+      })
+    },
+    getDynamicPackageDependencies: function (
+      info: ExtensionApiOptions,
+      babelConfigName = '.babelrc'
+    ) {
+      const packages: { [key: string]: string } = {}
+      const configFile = findByName(info.configFiles, mainConfigName)
+      const config = require(configFile.path)
+      const packageJson = loadPackageJsonSync(
+        info.context.componentDir,
+        info.context.workspaceDir
+      )
 
-    if (!Object.keys(configuration.entry).length) {
-        configuration.entry = {main: mainFile}
+      if (!packageJson) {
+        metaWebpack.logger!.log('Could not find package.json.')
+        return packages
+      }
+
+      function handleLoader (
+        packageJson: object,
+        name: string,
+        toFill: { [k: string]: string }
+      ) {
+        let babelResults = {}
+        if (name === 'babel-loader') {
+          babelResults = getBabelDynamicPackageDependencies(
+            metaWebpack.logger!,
+            babelConfigName
+          )(info)
+        }
+
+        fillDependencyVersion(packageJson, name, toFill)
+        Object.assign(toFill, babelResults)
+      }
+      _get(config, 'module.rules', []).forEach(function (rule: {
+        use?: string
+        loader?: string
+      }) {
+        if (Array.isArray(rule.use)) {
+          rule.use.forEach(function (internalUse) {
+            handleLoader(packageJson, internalUse.loader, packages)
+          })
+        }
+
+        if (rule.use) {
+          handleLoader(packageJson, rule.use, packages)
+        }
+
+        if (rule.loader) {
+          handleLoader(packageJson, rule.loader, packages)
+        }
+      })
+      return packages
     }
+  }
+  return metaWebpack
 }
-export function webpackFindConfiguration(info:ExtensionApiOptions, name:string){
-    return findConfiguration(info, {
-        [FindStrategy.pjKeyName]: 'webpack',
-        [FindStrategy.fileName]: name,
-        [FindStrategy.default]: DefaulftWebapckConfig,
-        [FindStrategy.defaultFilePaths]: [`./${name}`],
+
+function adjustConfigurationIfNeeded (
+  configuration: any,
+  mainFile: string,
+  _logger: Logger
+) {
+  if (
+    typeof configuration.entry === 'object' &&
+    Object.keys(configuration.entry).length > 1
+  ) {
+    let correctEntry: { [x: string]: string } = {}
+    Object.keys(configuration.entry).forEach(function (entry) {
+      const entryNamNoEnding = mainFile
+        .split('.')
+        .slice(0, -1)
+        .join('.')
+      if (
+        configuration.entry[entry].endsWith(mainFile) ||
+        configuration.entry[entry].endsWith(entryNamNoEnding)
+      ) {
+        correctEntry[entry] = configuration.entry[entry]
+      } else if (entry === 'test' || entry.endsWith('_test')) {
+        correctEntry[entry] = configuration.entry[entry]
+      }
     })
-}
+    configuration.entry = correctEntry
+  }
 
+  if (!Object.keys(configuration.entry).length) {
+    configuration.entry = { main: mainFile }
+  }
+}
+export function webpackFindConfiguration (
+  info: ExtensionApiOptions,
+  name: string
+) {
+  return findConfiguration(info, {
+    [FindStrategy.pjKeyName]: 'webpack',
+    [FindStrategy.fileName]: name,
+    [FindStrategy.default]: DefaulftWebapckConfig,
+    [FindStrategy.defaultFilePaths]: [`./${name}`]
+  })
+}
 
 export default CreateWebpackCompiler()

--- a/test/babel/babel.e2e.ts
+++ b/test/babel/babel.e2e.ts
@@ -1,31 +1,35 @@
 /// <reference path='eval.d.ts' />
-import {expect} from 'chai'
+import { expect } from 'chai'
 import path from 'path'
 import fs from 'fs-extra'
 import _eval from 'eval'
-import {e2eHelper} from '../e2e-helper'
-import {setup, generatePackageJson} from '../envs-test-utils'
+import { e2eHelper } from '../e2e-helper'
+import { setup, generatePackageJson } from '../envs-test-utils'
 import packageJSON from './private-package-json'
 
 describe('babel', function () {
-    const baseFixturePath = path.resolve(__dirname, './fixture')
-    const compilerPath = path.resolve(__dirname, '../../dist/src/babel')
-    const helper = e2eHelper({baseFixturePath,
-        mainFile:'b.js',
-        compilerName:'babel',
-        confName: ['.babelrc'],
-        compilerPath})
-    before(function () {
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
-        this.timeout(1000 * 1000)
-        helper.before()
-    })
-    after(function () {
-        helper.after()
-    })
-    it('bit should transpile component with babel meta compiler', function () {
-        const transpiled = fs.readFileSync(path.resolve(baseFixturePath, 'dist/b.js')).toString()
-        expect(_eval(transpiled).run()).to.equal(0)
-    })
+  const baseFixturePath = path.resolve(__dirname, './fixture')
+  const compilerPath = path.resolve(__dirname, '../../dist/src/babel')
+  const helper = e2eHelper({
+    baseFixturePath,
+    mainFile: 'b.js',
+    compilerName: 'babel',
+    confName: ['.babelrc'],
+    compilerPath
+  })
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+    this.timeout(1000 * 1000)
+    helper.before()
+  })
+  after(function () {
+    helper.after()
+  })
+  it('bit should transpile component with babel meta compiler', function () {
+    const transpiled = fs
+      .readFileSync(path.resolve(baseFixturePath, 'dist/b.js'))
+      .toString()
+    expect(_eval(transpiled).run()).to.equal(0)
+  })
 })

--- a/test/babel/eval.d.ts
+++ b/test/babel/eval.d.ts
@@ -1,1 +1,1 @@
-declare module 'eval';
+declare module 'eval'

--- a/test/babel/ignore-list.ts
+++ b/test/babel/ignore-list.ts
@@ -1,9 +1,9 @@
 export const ignoreList = [
-    '.babelrc',
-    'package.json',
-    'package-lock.json',
-    '.babelrc.only',
-    '.babelrc.ignore',
-    '.babelrc.empty',
-    '.gitignore'
+  '.babelrc',
+  'package.json',
+  'package-lock.json',
+  '.babelrc.only',
+  '.babelrc.ignore',
+  '.babelrc.empty',
+  '.gitignore'
 ]

--- a/test/babel/private-package-json-resolve.ts
+++ b/test/babel/private-package-json-resolve.ts
@@ -1,35 +1,35 @@
 const packageJson = {
-    name: 'envs-config',
-    version: '1.0.0',
-    description: '',
-    main: 'index.js',
-    scripts: {
-        test: 'echo \'Error: no test specified\' && exit 1'
-    },
-    keywords: [],
-    author: '',
-    license: 'ISC',
-    dependencies: {
-        'babel-preset-env': '^1.6.1',
-        'babel-preset-latest': '^6.24.1',
-        'babel-preset-react': "^6.24.1",
-        chai: '^4.1.2',
-        raven: '^2.4.2'
-    },
-    devDependencies: {
-        'babel-plugin-inline-react-svg': '^0.5.4',
-        'babel-plugin-object-values-to-object-keys': '^1.0.2',
-        'babel-plugin-transform-async-to-generator': '^6.24.1',
-        'babel-plugin-transform-async-to-module-method': '^6.24.1',
-        'babel-plugin-transform-class-properties': '^6.24.1',
-        'babel-plugin-transform-decorators-legacy': '^1.3.5',
-        'babel-plugin-transform-export-extensions': '^6.22.0',
-        'babel-plugin-transform-object-entries': '^1.0.0',
-        'babel-plugin-transform-object-rest-spread': '^6.26.0',
-        'babel-plugin-transform-react-jsx': '^6.24.1',
-        'babel-plugin-transform-regenerator': '^6.26.0',
-        bluebird: '^3.5.1'
-    }
-};
+  name: 'envs-config',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: "echo 'Error: no test specified' && exit 1"
+  },
+  keywords: [],
+  author: '',
+  license: 'ISC',
+  dependencies: {
+    'babel-preset-env': '^1.6.1',
+    'babel-preset-latest': '^6.24.1',
+    'babel-preset-react': '^6.24.1',
+    chai: '^4.1.2',
+    raven: '^2.4.2'
+  },
+  devDependencies: {
+    'babel-plugin-inline-react-svg': '^0.5.4',
+    'babel-plugin-object-values-to-object-keys': '^1.0.2',
+    'babel-plugin-transform-async-to-generator': '^6.24.1',
+    'babel-plugin-transform-async-to-module-method': '^6.24.1',
+    'babel-plugin-transform-class-properties': '^6.24.1',
+    'babel-plugin-transform-decorators-legacy': '^1.3.5',
+    'babel-plugin-transform-export-extensions': '^6.22.0',
+    'babel-plugin-transform-object-entries': '^1.0.0',
+    'babel-plugin-transform-object-rest-spread': '^6.26.0',
+    'babel-plugin-transform-react-jsx': '^6.24.1',
+    'babel-plugin-transform-regenerator': '^6.26.0',
+    bluebird: '^3.5.1'
+  }
+}
 
-export default packageJson;
+export default packageJson

--- a/test/babel/private-package-json.ts
+++ b/test/babel/private-package-json.ts
@@ -1,24 +1,24 @@
 const packageJson = {
-    name: 'envs-config',
-    version: '1.0.0',
-    description: '',
-    main: 'index.js',
-    scripts: {
-        test: 'echo \'Error: no test specified\' && exit 1'
-    },
-    keywords: [],
-    author: '',
-    license: 'ISC',
-    dependencies: {
-        'babel-plugin-transform-object-rest-spread': '^6.26.0',
-        'babel-preset-env': '^1.6.1',
-        'babel-preset-latest': '^6.24.1',
-        chai: '^4.1.2',
-        raven: '^2.4.2'
-    },
-    devDependencies: {
-        'babel-plugin-transform-async-to-module-method': '^6.24.1',
-        bluebird: '^3.5.1'
-    }
+  name: 'envs-config',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: "echo 'Error: no test specified' && exit 1"
+  },
+  keywords: [],
+  author: '',
+  license: 'ISC',
+  dependencies: {
+    'babel-plugin-transform-object-rest-spread': '^6.26.0',
+    'babel-preset-env': '^1.6.1',
+    'babel-preset-latest': '^6.24.1',
+    chai: '^4.1.2',
+    raven: '^2.4.2'
+  },
+  devDependencies: {
+    'babel-plugin-transform-async-to-module-method': '^6.24.1',
+    bluebird: '^3.5.1'
+  }
 }
 export default packageJson

--- a/test/e2e-helper.ts
+++ b/test/e2e-helper.ts
@@ -2,74 +2,87 @@ import path from 'path'
 import child_process from 'child_process'
 import fs from 'fs-extra'
 
-interface e2eHelperInfo {
-    baseFixturePath:string
-    mainFile:string
-    compilerName:string
-    confName:Array<string>
-    compilerPath:string
-    testerPath?:string
-    compFiles?:Array<string>
-    testFiles?:Array<string>
-    testerConfig?:object
+interface E2eHelperInfo {
+  baseFixturePath: string
+  mainFile: string
+  compilerName: string
+  confName: Array<string>
+  compilerPath: string
+  testerPath?: string
+  compFiles?: Array<string>
+  testFiles?: Array<string>
+  testerConfig?: object
 }
 
-export function e2eHelper(i:e2eHelperInfo) {
-    let cwd = ''
-    return {
-        before: function(){
-            cwd = process.cwd()
-            process.chdir(i.baseFixturePath)
-            const bitPath = require.resolve('bit-bin/bin/bit.js')
-            // const bitPath = '/usr/local/bin/bd'
-            const options = {}
-            // const options = {stdio: [0,1,2]}
-            const fileList = i.compFiles && i.compFiles.length > 0 ? i.compFiles.join(' '): '.'
-            child_process.execSync(bitPath + ' init', options)
-            child_process.execSync(`${bitPath} add ${fileList} --main ${i.mainFile} --id to-build `, options)
-            if (i.testFiles && i.testFiles.length > 0) {
-                child_process.execSync(`${bitPath} add -t ${i.testFiles.join(' ')} --id to-build `, options)
-            }
-            child_process.execSync(bitPath + ' tag to-build ', options)
-            const bitJson = require(path.resolve(i.baseFixturePath, './bit.json'))
-            const files = i.confName.reduce(function(prev:{[k:string]:string}, curr){
-                prev[curr] =  './' + curr
-                return prev
-            }, {})
+export function e2eHelper (i: E2eHelperInfo) {
+  let cwd = ''
+  return {
+    before: function () {
+      cwd = process.cwd()
+      process.chdir(i.baseFixturePath)
+      const bitPath = require.resolve('bit-bin/bin/bit.js')
+      // const bitPath = '/usr/local/bin/bd'
+      const options = {}
+      // const options = {stdio: [0,1,2]}
+      const fileList =
+        i.compFiles && i.compFiles.length > 0 ? i.compFiles.join(' ') : '.'
+      child_process.execSync(bitPath + ' init', options)
+      child_process.execSync(
+        `${bitPath} add ${fileList} --main ${i.mainFile} --id to-build `,
+        options
+      )
+      if (i.testFiles && i.testFiles.length > 0) {
+        child_process.execSync(
+          `${bitPath} add -t ${i.testFiles.join(' ')} --id to-build `,
+          options
+        )
+      }
+      child_process.execSync(bitPath + ' tag to-build ', options)
+      const bitJson = require(path.resolve(i.baseFixturePath, './bit.json'))
+      const files = i.confName.reduce(function (
+        prev: { [k: string]: string },
+        curr
+      ) {
+        prev[curr] = './' + curr
+        return prev
+      },
+      {})
 
-            if (i.compilerName) {
-                bitJson.env.compiler = {
-                    [`meta-${i.compilerName}`]: {
-                        files,
-                        'options': {
-                            'file': i.compilerPath
-                        }
-                    }
-                }
+      if (i.compilerName) {
+        bitJson.env.compiler = {
+          [`meta-${i.compilerName}`]: {
+            files,
+            options: {
+              file: i.compilerPath
             }
-            if (i.testerPath && i.testerConfig) {
-                bitJson.env.tester = i.testerConfig
-            } else if (i.testerPath) {
-                bitJson.env.tester = {
-                    [`meta-tester`]: {
-                        files,
-                        'options': {
-                            'file': i.testerPath
-                        }
-                    }
-                }
-            }
-            fs.writeFileSync('./bit.json', JSON.stringify(bitJson))
-            // return child_process.execSync(`node --inspect-brk ${bitPath} ${(i.testerPath ? ' test': ' build')}`, options)
-            return child_process.execSync(`${bitPath} ${(i.testerPath ? ' test': ' build')}`, options)
-        },
-
-        after: function () {
-            fs.unlinkSync(path.resolve(i.baseFixturePath, 'bit.json'))
-            fs.unlinkSync(path.resolve(i.baseFixturePath, '.bitmap'))
-            fs.removeSync(path.resolve(i.baseFixturePath, '.bit'))
-            fs.removeSync(path.resolve(i.baseFixturePath, 'dist'))
-            process.chdir(cwd)
+          }
         }
+      }
+      if (i.testerPath && i.testerConfig) {
+        bitJson.env.tester = i.testerConfig
+      } else if (i.testerPath) {
+        bitJson.env.tester = {
+          [`meta-tester`]: {
+            files,
+            options: {
+              file: i.testerPath
+            }
+          }
+        }
+      }
+      fs.writeFileSync('./bit.json', JSON.stringify(bitJson))
+      return child_process.execSync(
+        `${bitPath} ${i.testerPath ? ' test' : ' build'}`,
+        options
+      )
+    },
+
+    after: function () {
+      fs.unlinkSync(path.resolve(i.baseFixturePath, 'bit.json'))
+      fs.unlinkSync(path.resolve(i.baseFixturePath, '.bitmap'))
+      fs.removeSync(path.resolve(i.baseFixturePath, '.bit'))
+      fs.removeSync(path.resolve(i.baseFixturePath, 'dist'))
+      process.chdir(cwd)
     }
+  }
 }

--- a/test/envs-test-utils.ts
+++ b/test/envs-test-utils.ts
@@ -4,82 +4,105 @@ import fs from 'fs-extra'
 import _get from 'lodash.get'
 import child_process from 'child_process'
 
-export function createApi(){
-    return {
-        getLogger: () => ({
-            log:console.log,
-            error:console.error
-        })
+export function createApi () {
+  return {
+    getLogger: () => ({
+      log: console.log,
+      error: console.error
+    })
+  }
+}
+
+export function createConfigFile (
+  baseFixturePath: string,
+  name = 'webpack.config.js'
+): Vinyl {
+  const configPath = path.resolve(baseFixturePath, name)
+  return new Vinyl({
+    name: name,
+    path: configPath,
+    contents: Buffer.from(fs.readFileSync(configPath))
+  })
+}
+
+export function getVersion (packageJSON: any, name: string) {
+  return (
+    _get(packageJSON, `dependencies[${name}]`) ||
+    _get(packageJSON, `devDependencies[${name}]`)
+  )
+}
+
+export function createFiles (
+  fixturePath: string,
+  skipFiles: Array<string> = [],
+  acceptRule: string | null = null
+): Array<Vinyl> {
+  return fs
+    .readdirSync(fixturePath)
+    .filter(function (fileName) {
+      return (
+        (acceptRule && fileName.endsWith(acceptRule)) ||
+        (!fs
+          .lstatSync(path.resolve(fixturePath, `./${fileName}`))
+          .isDirectory() &&
+          !~skipFiles.indexOf(fileName))
+      )
+    })
+    .map(function (fileName) {
+      const pathToFile = path.resolve(fixturePath, `./${fileName}`)
+      return new Vinyl({
+        path: pathToFile,
+        contents: Buffer.from(fs.readFileSync(pathToFile))
+      })
+    })
+}
+
+export function setup (context: Mocha.Context, paths: Array<string>) {
+  if (process.env['NO_INSTALL']) {
+    return
+  }
+
+  context.timeout(1000 * 1000)
+  paths.forEach(function (fixturePath) {
+    if (
+      fs.lstatSync(fixturePath).isDirectory() &&
+      !fs.existsSync(path.resolve(fixturePath, '.npm-skip'))
+    ) {
+      const cwd = process.cwd()
+      process.chdir(fixturePath)
+      child_process.execSync('npm i')
+      process.chdir(cwd)
     }
+  })
 }
 
-export function createConfigFile(baseFixturePath:string, name = 'webpack.config.js'): Vinyl   {
-    const configPath = path.resolve(baseFixturePath, name)
-    return new Vinyl({
-        name: name,
-        path: configPath,
-        contents: Buffer.from(fs.readFileSync(configPath))
-    })
-}
-
-export function getVersion(packageJSON:any, name:string) {
-    return _get(packageJSON, `dependencies[${name}]`) || _get(packageJSON, `devDependencies[${name}]`)
-}
-
-export function createFiles(fixturePath:string, skipFiles:Array<string> = [], acceptRule:string | null = null ):Array<Vinyl> {
-    return fs.readdirSync(fixturePath)
-    .filter(function(fileName) {
-        return (acceptRule && fileName.endsWith(acceptRule)) ||
-            !fs.lstatSync(path.resolve(fixturePath, `./${fileName}`)).isDirectory() &&
-            !~skipFiles.indexOf(fileName)
-    })
-    .map(function(fileName){
-        const pathToFile = path.resolve(fixturePath, `./${fileName}`)
-        return new Vinyl({
-            path: pathToFile,
-            contents: Buffer.from(fs.readFileSync(pathToFile))
-        })
-    })
-}
-
-export function setup(context:Mocha.Context, paths: Array<string>) {
-    if(process.env['NO_INSTALL']){
-        return
+export function generatePackageJson (toInstall: { [path: string]: any }) {
+  Object.keys(toInstall).forEach(function (fixturePath: string) {
+    if (fs.lstatSync(fixturePath).isDirectory()) {
+      fs.writeJSONSync(`${fixturePath}/package.json`, toInstall[fixturePath])
     }
-
-    context.timeout(1000*1000)
-    paths.forEach(function(fixturePath){
-        if (fs.lstatSync(fixturePath).isDirectory() &&
-            !fs.existsSync(path.resolve(fixturePath, '.npm-skip')))  {
-            const cwd = process.cwd()
-            process.chdir(fixturePath)
-            child_process.execSync('npm i')
-            process.chdir(cwd)
-        }
-    })
+  })
 }
 
-export function generatePackageJson(toInstall: {[path:string]:any}){
-    Object.keys(toInstall).forEach(function(fixturePath:string){
-        if (fs.lstatSync(fixturePath).isDirectory()){
-            fs.writeJSONSync(`${fixturePath}/package.json`, toInstall[fixturePath])
-        }
-    })
-}
-
-export function createExtensionInfo (configName:string, fixturePath:string,  skipFiles: Array<string> = []):any {
-    const files = createFiles(fixturePath, skipFiles)
-    const config = fs.existsSync(path.resolve(fixturePath, configName)) ? createConfigFile(fixturePath, configName) : null
-    return {
-        files,
-        configFiles:  config ? [config]: [],
-        context: {
-            componentDir: fixturePath,
-            componentObject: {
-                mainFile: ''
-            },
-            rootDistDir: path.resolve(fixturePath, './dist')
-        },
-        rawConfig: {}
-    }
+export function createExtensionInfo (
+  configName: string,
+  fixturePath: string,
+  skipFiles: Array<string> = []
+): any {
+  const files = createFiles(fixturePath, skipFiles)
+  const config = fs.existsSync(path.resolve(fixturePath, configName))
+    ? createConfigFile(fixturePath, configName)
+    : null
+  return {
+    files,
+    configFiles: config ? [config] : [],
+    context: {
+      componentDir: fixturePath,
+      componentObject: {
+        mainFile: ''
+      },
+      rootDistDir: path.resolve(fixturePath, './dist')
+    },
+    rawConfig: {}
+  }
 }

--- a/test/jest/fixture-action/add.ts
+++ b/test/jest/fixture-action/add.ts
@@ -1,3 +1,3 @@
-export function add(a:number, b:number){
-    return a + b
+export function add (a: number, b: number) {
+  return a + b
 }

--- a/test/jest/fixture-action/index.ts
+++ b/test/jest/fixture-action/index.ts
@@ -1,10 +1,8 @@
-import {add} from './add'
-import {sub} from './sub'
-export {add}
-export {sub}
+import { add } from './add'
+import { sub } from './sub'
+export { add }
+export { sub }
 
-export function run() {
-    return add(sub(1,2),1)
+export function run () {
+  return add(sub(1, 2), 1)
 }
-
-

--- a/test/jest/fixture-action/sub.ts
+++ b/test/jest/fixture-action/sub.ts
@@ -1,3 +1,3 @@
-export function sub(a:number, b:number){
-    return a - b
+export function sub (a: number, b: number) {
+  return a - b
 }

--- a/test/jest/fixture-action/test.spec.ts
+++ b/test/jest/fixture-action/test.spec.ts
@@ -1,17 +1,17 @@
-import {expect} from 'chai'
-import {run, add, sub} from './index'
+import { expect } from 'chai'
+import { run, add, sub } from './index'
 
-describe('basic', function (){
-    it('should add/sub properly', function() {
-        expect(run()).to.equal(0)
-    })
-    it('add', function() {
-        expect(add(1, 1)).to.equal(2)
-    })
-    it('sub', function() {
-        expect(sub(3, 1)).to.equal(2)
-    })
-    it('supports preloading files with the jest `setupFiles` field', function() {
-        expect((global as any).jestSetupFilesRun).to.equal(true)
-    })
+describe('basic', function () {
+  it('should add/sub properly', function () {
+    expect(run()).to.equal(0)
+  })
+  it('add', function () {
+    expect(add(1, 1)).to.equal(2)
+  })
+  it('sub', function () {
+    expect(sub(3, 1)).to.equal(2)
+  })
+  it('supports preloading files with the jest `setupFiles` field', function () {
+    expect((global as any).jestSetupFilesRun).to.equal(true)
+  })
 })

--- a/test/jest/fixture-action/test2.spec.ts
+++ b/test/jest/fixture-action/test2.spec.ts
@@ -1,14 +1,14 @@
-import {expect} from 'chai'
-import {run, add, sub} from './index'
+import { expect } from 'chai'
+import { run, add, sub } from './index'
 
-describe('basic', function (){
-    it('should add/sub properly', function() {
-        expect(run()).to.equal(0)
-    })
-    it('add', function() {
-        expect(add(1, 1)).to.equal(2)
-    })
-    it('sub', function() {
-        expect(sub(3, 1)).to.equal(2)
-    })
+describe('basic', function () {
+  it('should add/sub properly', function () {
+    expect(run()).to.equal(0)
+  })
+  it('add', function () {
+    expect(add(1, 1)).to.equal(2)
+  })
+  it('sub', function () {
+    expect(sub(3, 1)).to.equal(2)
+  })
 })

--- a/test/jest/fixture-configuration/add.ts
+++ b/test/jest/fixture-configuration/add.ts
@@ -1,3 +1,3 @@
-export function add(a:number, b:number){
-    return a + b
+export function add (a: number, b: number) {
+  return a + b
 }

--- a/test/jest/fixture-configuration/index.ts
+++ b/test/jest/fixture-configuration/index.ts
@@ -1,10 +1,8 @@
-import {add} from './add'
-import {sub} from './sub'
-export {add}
-export {sub}
+import { add } from './add'
+import { sub } from './sub'
+export { add }
+export { sub }
 
-export function run() {
-    return add(sub(1,2),1)
+export function run () {
+  return add(sub(1, 2), 1)
 }
-
-

--- a/test/jest/fixture-configuration/sub.ts
+++ b/test/jest/fixture-configuration/sub.ts
@@ -1,3 +1,3 @@
-export function sub(a:number, b:number){
-    return a - b
+export function sub (a: number, b: number) {
+  return a - b
 }

--- a/test/jest/jest.e2e.ts
+++ b/test/jest/jest.e2e.ts
@@ -1,34 +1,35 @@
 import path from 'path'
-import {expect} from 'chai'
-import {e2eHelper} from '../e2e-helper'
-import { setup, generatePackageJson } from '../envs-test-utils';
+import { expect } from 'chai'
+import { e2eHelper } from '../e2e-helper'
+import { setup, generatePackageJson } from '../envs-test-utils'
 import packageJSON from './private-package-json'
 
-describe('jest', function (){
-    const baseFixturePath = path.resolve(__dirname, './fixture-action')
-    const compilerPath = ''
-    const testerPath = path.resolve(__dirname, '../../dist/src/jest')
-    const helper = e2eHelper({baseFixturePath,
-        mainFile:'index.ts',
-        compilerName:'',
-        confName: ['jest.config.js'],
-        compilerPath,
-        testerPath,
-        compFiles:['index.ts', 'add.ts', 'sub.ts', 'setup.ts'],
-        testFiles:['test.spec.ts', 'test2.spec.ts']
-    })
-    let mainCommandResult = ''
-    before(function () {
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
-        this.timeout(1000 * 1000)
-        mainCommandResult = helper.before().toString()
-    })
-    after(function () {
-        helper.after()
-    })
-    it('bit should test component with jest meta tester', function () {
-        expect(mainCommandResult).to.contain('tests passed')
-        expect(mainCommandResult).to.not.contain('tests failed')
-    })
+describe('jest', function () {
+  const baseFixturePath = path.resolve(__dirname, './fixture-action')
+  const compilerPath = ''
+  const testerPath = path.resolve(__dirname, '../../dist/src/jest')
+  const helper = e2eHelper({
+    baseFixturePath,
+    mainFile: 'index.ts',
+    compilerName: '',
+    confName: ['jest.config.js'],
+    compilerPath,
+    testerPath,
+    compFiles: ['index.ts', 'add.ts', 'sub.ts', 'setup.ts'],
+    testFiles: ['test.spec.ts', 'test2.spec.ts']
+  })
+  let mainCommandResult = ''
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+    this.timeout(1000 * 1000)
+    mainCommandResult = helper.before().toString()
+  })
+  after(function () {
+    helper.after()
+  })
+  it('bit should test component with jest meta tester', function () {
+    expect(mainCommandResult).to.contain('tests passed')
+    expect(mainCommandResult).to.not.contain('tests failed')
+  })
 })

--- a/test/jest/jest.spec.ts
+++ b/test/jest/jest.spec.ts
@@ -1,98 +1,115 @@
 import path from 'path'
 import { expect } from 'chai'
 import { CreateJestTester } from '../../src/jest'
-import { createApi, createConfigFile, createFiles, setup, generatePackageJson} from '../envs-test-utils'
-import { getVersion } from '../../src/env-utils';
+import {
+  createApi,
+  createConfigFile,
+  createFiles,
+  setup,
+  generatePackageJson
+} from '../envs-test-utils'
+import { getVersion } from '../../src/env-utils'
 import packageJSON from './private-package-json'
 import packageJSONNoAction from './private-package-json-empty'
 import packageJSONConf from './private-package-json-conf'
 
 describe('jest', function () {
-    before(function(){
-        generatePackageJson({[fixtureAction]:packageJSON,
-                            [baseFixturePath]:packageJSONNoAction,
-                            [fixtureConfiguration]:packageJSONConf})
-        setup(this, [baseFixturePath, fixtureAction, fixtureConfiguration])
+  before(function () {
+    generatePackageJson({
+      [fixtureAction]: packageJSON,
+      [baseFixturePath]: packageJSONNoAction,
+      [fixtureConfiguration]: packageJSONConf
+    })
+    setup(this, [baseFixturePath, fixtureAction, fixtureConfiguration])
+  })
+
+  const fixtureAction = path.resolve(__dirname, './fixture-action')
+  const baseFixturePath = path.resolve(__dirname, './fixture')
+  const fixtureConfiguration = path.resolve(
+    __dirname,
+    './fixture-configuration'
+  )
+
+  it('init', function () {
+    const tester = CreateJestTester()
+    const options = tester.init({ api: createApi() })
+    expect(!!tester.logger).to.equal(true)
+    expect(!!options.write).to.equal(true)
+  })
+  it('getDynamicPackageDependencies', function () {
+    const packageJSON = packageJSONNoAction
+    const tester = CreateJestTester()
+    const context = {
+      componentDir: baseFixturePath
+    }
+    const config = createConfigFile(baseFixturePath, 'jest.config.js')
+    tester.init({
+      api: createApi()
     })
 
-    const fixtureAction = path.resolve(__dirname, './fixture-action')
-    const baseFixturePath = path.resolve(__dirname, './fixture')
-    const fixtureConfiguration = path.resolve(__dirname, './fixture-configuration')
-
-    it('init', function () {
-        const tester = CreateJestTester()
-        const options = tester.init({ api: createApi() })
-        expect(!!tester.logger).to.be.true
-        expect(options.write).to.be.true
+    const results = tester.getDynamicPackageDependencies({
+      configFiles: [config],
+      context
     })
-    it('getDynamicPackageDependencies', function () {
-        const packageJSON = packageJSONNoAction
-        const tester = CreateJestTester()
-        const context = {
-            componentDir: baseFixturePath
-        }
-        const config = createConfigFile(baseFixturePath, 'jest.config.js')
-        tester.init({
-            api: createApi()
-        })
-
-        const results = tester.getDynamicPackageDependencies({ configFiles: [config], context })
-        expect(results).to.contain({
-            'ts-jest': getVersion(packageJSON, 'ts-jest'),
-            'babel-jest': getVersion(packageJSON, 'babel-jest'),
-            'some-module': getVersion(packageJSON, 'some-module'),
-            'dom': getVersion(packageJSON, 'dom'),
-            'serialize': getVersion(packageJSON, 'serialize')
-        })
+    expect(results).to.contain({
+      'ts-jest': getVersion(packageJSON, 'ts-jest'),
+      'babel-jest': getVersion(packageJSON, 'babel-jest'),
+      'some-module': getVersion(packageJSON, 'some-module'),
+      dom: getVersion(packageJSON, 'dom'),
+      serialize: getVersion(packageJSON, 'serialize')
     })
+  })
 
-    it('action', function () {
-        this.timeout(5000 * 10 )
-        const configName = 'jest.config.js'
-        const tester = CreateJestTester()
-        const testFiles = createFiles(fixtureAction, [configName, 'package.json', 'package-lock.json', '.gitignore'])
-        const config = createConfigFile(fixtureAction, configName)
-        const actionInfo = {
-            testFiles,
-            configFiles: [config],
-            context: {
-                componentDir: fixtureAction,
-                componentObject: {
-                    mainFile: 'index.ts'
-                },
-                rootDistDir: path.resolve(fixtureAction, './dist')
-            }
-        }
-        tester.init({ api: createApi() })
-        return tester.action(actionInfo).then(function(results) {
-            expect(results.length).to.be.greaterThan(0)
-            results.forEach(function(test){
-                expect(!!test.specPath).to.be.true
-                expect(test.failures.length, 'failing tests').to.equal(0)
-                test.tests.forEach((test:any)=>expect(test.pass).to.be.true)
-            })
-        })
-    }),
-    it('should support dynamic config lookup', function(){
-        const testFiles = createFiles(fixtureConfiguration, ['package.json', 'package-lock.json', '.gitignore'])
-        const actionInfo = {
-            testFiles,
-            configFiles: [],
-            context: {
-                componentDir: fixtureConfiguration,
-                componentObject: {
-                    mainFile: 'index.ts'
-                },
-                rootDistDir: path.resolve(fixtureConfiguration, './dist')
-            }
-        }
-        const tester = CreateJestTester()
-        tester.init({ api: createApi() })
-        const dynamicConfig = tester.getDynamicConfig!(actionInfo)
-        expect(dynamicConfig.jest).to.deep.equal(packageJSONConf.jest)
-
+  it('action', function () {
+    this.timeout(5000 * 10)
+    const configName = 'jest.config.js'
+    const tester = CreateJestTester()
+    const testFiles = createFiles(
+      fixtureAction,
+      [configName, 'package.json', 'package-lock.json', '.gitignore']
+    )
+    const config = createConfigFile(fixtureAction, configName)
+    const actionInfo = {
+      testFiles,
+      configFiles: [config],
+      context: {
+        componentDir: fixtureAction,
+        componentObject: {
+          mainFile: 'index.ts'
+        },
+        rootDistDir: path.resolve(fixtureAction, './dist')
+      }
+    }
+    tester.init({ api: createApi() })
+    return tester.action(actionInfo).then(function (results) {
+      expect(results.length).to.be.greaterThan(0)
+      results.forEach(function (test) {
+        expect(!!test.specPath).to.equal(true)
+        expect(test.failures.length, 'failing tests').to.equal(0)
+        test.tests.forEach((test: any) => expect(test.pass).to.be.true)
+      })
     })
+  }),
+  it('should support dynamic config lookup', function () {
+    const testFiles = createFiles(fixtureConfiguration, [
+      'package.json',
+      'package-lock.json',
+      '.gitignore'
+    ])
+    const actionInfo = {
+      testFiles,
+      configFiles: [],
+      context: {
+        componentDir: fixtureConfiguration,
+        componentObject: {
+          mainFile: 'index.ts'
+        },
+        rootDistDir: path.resolve(fixtureConfiguration, './dist')
+      }
+    }
+    const tester = CreateJestTester()
+    tester.init({ api: createApi() })
+    const dynamicConfig = tester.getDynamicConfig!(actionInfo)
+    expect(dynamicConfig.jest).to.deep.equal(packageJSONConf.jest)
+  })
 })
-
-
-

--- a/test/jest/private-package-json-conf.ts
+++ b/test/jest/private-package-json-conf.ts
@@ -1,38 +1,30 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        '@types/jest': '23.3.1',
-        'babel-jest': '23.4.2',
-        jest: '23.4.2',
-        rimraf: '2.6.2',
-        'ts-jest': '23.0.1',
-        typescript: '2.7.1'
+  main: './dist/index',
+  devDependencies: {
+    '@types/jest': '23.3.1',
+    'babel-jest': '23.4.2',
+    jest: '23.4.2',
+    rimraf: '2.6.2',
+    'ts-jest': '23.0.1',
+    typescript: '2.7.1'
+  },
+  scripts: {
+    build: 'tsc -d',
+    clean: 'rimraf dist/*',
+    test: 'jest'
+  },
+  dependencies: {},
+  jest: {
+    testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+    transform: {
+      '^.+\\.jsx?$': '<rootDir>/node_modules/babel-jest',
+      '^.+\\.tsx?$': 'ts-jest'
     },
-    scripts: {
-        build: 'tsc -d',
-        clean: 'rimraf dist/*',
-        test: 'jest'
-    },
-    dependencies: {},
-    jest:  {
-        testRegex: "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-        transform: {
-            "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",
-            "^.+\\.tsx?$": "ts-jest"
-        },
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ],
-        testPathIgnorePatterns: [
-            "/node_modules/",
-            "/.git/"
-        ],
-        "setupFiles": [],
-        "testEnvironment": "node"
-    }
-
+    moduleFileExtensions: ['ts', 'tsx', 'js'],
+    testPathIgnorePatterns: ['/node_modules/', '/.git/'],
+    setupFiles: [],
+    testEnvironment: 'node'
+  }
 }
 
-export default packageJson;
+export default packageJson

--- a/test/jest/private-package-json-empty.ts
+++ b/test/jest/private-package-json-empty.ts
@@ -1,25 +1,25 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        '@types/jest': '^23.3.1',
-        jest: '^23.4.2',
-        rimraf: '^2.6.2',
-        'ts-jest': '^23.0.1',
-        'ts-loader': '^4.4.2',
-        typescript: '2.7.1',
-        'babel-jest': '^23.4.2',
-        'some-module': '1.1.1',
-        'pretty-module': '1.2.3',
-        dom: '1.5.6',
-        serialize: '1.4.5'
-    },
-    scripts: {
-        build: 'tsc -d',
-        clean: 'rimraf dist/*'
-    },
-    dependencies: {
-        '@types/react': '^16.4.6'
-    }
+  main: './dist/index',
+  devDependencies: {
+    '@types/jest': '^23.3.1',
+    jest: '^23.4.2',
+    rimraf: '^2.6.2',
+    'ts-jest': '^23.0.1',
+    'ts-loader': '^4.4.2',
+    typescript: '2.7.1',
+    'babel-jest': '^23.4.2',
+    'some-module': '1.1.1',
+    'pretty-module': '1.2.3',
+    dom: '1.5.6',
+    serialize: '1.4.5'
+  },
+  scripts: {
+    build: 'tsc -d',
+    clean: 'rimraf dist/*'
+  },
+  dependencies: {
+    '@types/react': '^16.4.6'
+  }
 }
 
 export default packageJson

--- a/test/jest/private-package-json.ts
+++ b/test/jest/private-package-json.ts
@@ -1,19 +1,19 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        '@types/jest': '23.3.1',
-        'babel-jest': '23.4.2',
-        jest: '23.4.2',
-        rimraf: '2.6.2',
-        'ts-jest': '23.0.1',
-        typescript: '2.7.1'
-    },
-    scripts: {
-        build: 'tsc -d',
-        clean: 'rimraf dist/*',
-        test: 'jest'
-    },
-    dependencies: {}
+  main: './dist/index',
+  devDependencies: {
+    '@types/jest': '23.3.1',
+    'babel-jest': '23.4.2',
+    jest: '23.4.2',
+    rimraf: '2.6.2',
+    'ts-jest': '23.0.1',
+    typescript: '2.7.1'
+  },
+  scripts: {
+    build: 'tsc -d',
+    clean: 'rimraf dist/*',
+    test: 'jest'
+  },
+  dependencies: {}
 }
 
-export default packageJson;
+export default packageJson

--- a/test/mocha/mocha.e2e.ts
+++ b/test/mocha/mocha.e2e.ts
@@ -1,47 +1,47 @@
 import { expect } from 'chai'
 import path from 'path'
 import { e2eHelper } from '../e2e-helper'
-import { setup, generatePackageJson } from '../envs-test-utils';
+import { setup, generatePackageJson } from '../envs-test-utils'
 import packageJSON from './private-package-json'
 
-describe('mocha', function() {
-    const baseFixturePath = path.resolve(__dirname, './fixture')
-    const compilerPath = path.resolve(__dirname, '../../dist/src/babel')
-    const testerPath = path.resolve(__dirname, '../../dist/src/mocha')
-    const testerConfig = {
-        [`meta-tester`]: {
-            rawConfig: {
-                require: ['babel-core/register', 'source-map-support/register'],
-                filesRequire: ['setup.js']
-            },
-            options: {
-                file: testerPath
-            }
-        }
+describe('mocha', function () {
+  const baseFixturePath = path.resolve(__dirname, './fixture')
+  const compilerPath = path.resolve(__dirname, '../../dist/src/babel')
+  const testerPath = path.resolve(__dirname, '../../dist/src/mocha')
+  const testerConfig = {
+    [`meta-tester`]: {
+      rawConfig: {
+        require: ['babel-core/register', 'source-map-support/register'],
+        filesRequire: ['setup.js']
+      },
+      options: {
+        file: testerPath
+      }
     }
-    const helper = e2eHelper({
-        baseFixturePath,
-        mainFile: 'index.js',
-        compilerName: 'babel',
-        confName: ['.babelrc'],
-        compilerPath,
-        testerPath,
-        compFiles: ['index.js', 'add.js', 'sub.js', 'setup.js'],
-        testFiles: ['test.spec.js'],
-        testerConfig
-    })
-    let mainCommandResult = ''
-    before(function() {
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
-        this.timeout(1000 * 1000)
-        mainCommandResult = helper.before().toString()
-    })
-    after(function() {
-        helper.after()
-    })
-    it('bit should test component with mocha meta tester', function() {
-        expect(mainCommandResult).to.contain('tests passed')
-        expect(mainCommandResult).to.not.contain('tests failed')
-    })
+  }
+  const helper = e2eHelper({
+    baseFixturePath,
+    mainFile: 'index.js',
+    compilerName: 'babel',
+    confName: ['.babelrc'],
+    compilerPath,
+    testerPath,
+    compFiles: ['index.js', 'add.js', 'sub.js', 'setup.js'],
+    testFiles: ['test.spec.js'],
+    testerConfig
+  })
+  let mainCommandResult = ''
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+    this.timeout(1000 * 1000)
+    mainCommandResult = helper.before().toString()
+  })
+  after(function () {
+    helper.after()
+  })
+  it('bit should test component with mocha meta tester', function () {
+    expect(mainCommandResult).to.contain('tests passed')
+    expect(mainCommandResult).to.not.contain('tests failed')
+  })
 })

--- a/test/mocha/mocha.spec.ts
+++ b/test/mocha/mocha.spec.ts
@@ -1,106 +1,129 @@
 import path from 'path'
-import {expect} from 'chai'
-import {CreateMochaTester} from '../../src/mocha'
-import {createApi, createFiles, setup, generatePackageJson} from '../envs-test-utils'
-import { getVersion } from '../../src/env-utils';
+import { expect } from 'chai'
+import { CreateMochaTester } from '../../src/mocha'
+import {
+  createApi,
+  createFiles,
+  setup,
+  generatePackageJson
+} from '../envs-test-utils'
+import { getVersion } from '../../src/env-utils'
 import packageJSON from './private-package-json'
 
 describe('mocha', function () {
-    const baseFixturePath = path.resolve(__dirname, './fixture')
-    before(function(){
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
-    })
-    it('init', function () {
-        const tester = CreateMochaTester()
-        const options = tester.init({ api: createApi() })
-        expect(!!tester.logger).to.be.true
-        expect(options.write).to.be.false
+  const baseFixturePath = path.resolve(__dirname, './fixture')
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+  })
+  it('init', function () {
+    const tester = CreateMochaTester()
+    const options = tester.init({ api: createApi() })
+    expect(!!tester.logger).to.equal(true)
+    expect(!!options.write).to.equal(false)
+  })
+  describe('getDynamicPackageDependencies', function () {
+    this.timeout(5000)
+    it('getDynamicPackageDependencies', function () {
+      const tester = CreateMochaTester()
+      const context = {
+        componentDir: baseFixturePath
+      }
+      tester.init({
+        api: createApi()
+      })
 
-    })
-    describe('getDynamicPackageDependencies', function(){
-        this.timeout(5000)
-        it('getDynamicPackageDependencies', function () {
-            const tester = CreateMochaTester()
-            const context = {
-                componentDir: baseFixturePath
-            }
-            tester.init({
-                api: createApi()
-            })
+      const dynamicConfig = {
+        require: ['babel-core/register', 'source-map-support/register'],
+        filesRequire: ['setup.js']
+      }
+      const results = tester.getDynamicPackageDependencies({
+        configFiles: [],
+        context,
+        dynamicConfig
+      })
 
-            const dynamicConfig = {
-                'require': ['babel-core/register', 'source-map-support/register'],
-                'filesRequire': ['setup.js']
-            }
-            const results = tester.getDynamicPackageDependencies({configFiles:[], context, dynamicConfig})
+      const packageJSON = require(path.resolve(
+        baseFixturePath,
+        './package.json'
+      ))
+      expect(results).to.contain({
+        'babel-core': getVersion(packageJSON, 'babel-core'),
+        'source-map-support': getVersion(packageJSON, 'source-map-support')
+      })
+    })
+  })
 
-            const packageJSON = require(path.resolve(baseFixturePath, './package.json'))
-            expect(results).to.contain({
-                'babel-core':getVersion(packageJSON, 'babel-core'),
-                'source-map-support': getVersion(packageJSON, 'source-map-support')
-            })
-        })
+  it('action', function () {
+    const tester = CreateMochaTester()
+    const testFiles = createFiles(baseFixturePath, [
+      '.babelrc',
+      'package.json',
+      'package-lock.json',
+      '.gitignore'
+    ])
+    const actionInfo = {
+      testFiles,
+      configFiles: [],
+      dynamicConfig: {
+        require: ['babel-core/register', 'source-map-support/register'],
+        filesRequire: ['setup.js']
+      },
+      context: {
+        componentDir: baseFixturePath,
+        componentObject: {
+          mainFile: ''
+        },
+        rootDistDir: path.resolve(baseFixturePath, './dist')
+      }
+    }
+    tester.init({
+      api: createApi()
     })
-
-    it('action', function () {
-        const tester = CreateMochaTester()
-        const testFiles = createFiles(baseFixturePath, ['.babelrc', 'package.json', 'package-lock.json', '.gitignore'])
-        const actionInfo = {
-            testFiles,
-            configFiles: [],
-            dynamicConfig: {
-                'require': ['babel-core/register', 'source-map-support/register'],
-                'filesRequire': ['setup.js']
-            },
-            context: {
-                componentDir: baseFixturePath,
-                componentObject: {
-                    mainFile: ''
-                },
-                rootDistDir: path.resolve(baseFixturePath, './dist')
-            }
-        }
-        tester.init({
-            api:createApi()
-        })
-        return tester.action(actionInfo)
-            .then(function(results){
-                expect((global as any).mochaSetupTestRun, 'setup.js').to.be.true
-                const babelCore = Object.keys(require.cache).find((elem) => !!~elem.indexOf('babel-core/register'))
-                expect(babelCore, 'babel-core').to.contain('fixture')
-                const withFailures = results.find((item)=>item.specPath.endsWith('test2.spec.js'))
-                const allPassing = results.find((item)=>item.specPath.endsWith('test.spec.js'))
-                expect(withFailures.failures.length).to.equal(3)
-                expect(allPassing.failures.length).to.equal(0)
-            })
+    return tester.action(actionInfo).then(function (results) {
+      expect((global as any).mochaSetupTestRun, 'setup.js').to.equal(true)
+      const babelCore = Object.keys(require.cache).find(
+        elem => !!~elem.indexOf('babel-core/register')
+      )
+      expect(babelCore, 'babel-core').to.contain('fixture')
+      const withFailures = results.find(item =>
+        item.specPath.endsWith('test2.spec.js')
+      )
+      const allPassing = results.find(item =>
+        item.specPath.endsWith('test.spec.js')
+      )
+      expect(withFailures.failures.length).to.equal(3)
+      expect(allPassing.failures.length).to.equal(0)
     })
-    it('should support dynamic config lookup', function () {
-        const tester = CreateMochaTester()
-        const testFiles = createFiles(baseFixturePath, ['.babelrc', 'package.json', 'package-lock.json', '.gitignore'])
-        const actionInfo = {
-            testFiles,
-            configFiles: [],
-            dynamicConfig: {
-                'require': ['babel-core/register', 'source-map-support/register'],
-                'filesRequire': ['setup.js']
-            },
-            rawConfig: {foo: 'bar'},
-            context: {
-                componentDir: baseFixturePath,
-                componentObject: {
-                    mainFile: '',
-                },
-                rootDistDir: path.resolve(baseFixturePath, './dist')
-            }
-        }
-        tester.init({
-            api:createApi()
-        })
-        let config = tester.getDynamicConfig!(actionInfo)
-        expect(config).to.deep.equal(actionInfo.rawConfig)
+  })
+  it('should support dynamic config lookup', function () {
+    const tester = CreateMochaTester()
+    const testFiles = createFiles(baseFixturePath, [
+      '.babelrc',
+      'package.json',
+      'package-lock.json',
+      '.gitignore'
+    ])
+    const actionInfo = {
+      testFiles,
+      configFiles: [],
+      dynamicConfig: {
+        require: ['babel-core/register', 'source-map-support/register'],
+        filesRequire: ['setup.js']
+      },
+      rawConfig: { foo: 'bar' },
+      context: {
+        componentDir: baseFixturePath,
+        componentObject: {
+          mainFile: ''
+        },
+        rootDistDir: path.resolve(baseFixturePath, './dist')
+      }
+    }
+    tester.init({
+      api: createApi()
     })
+    let config = tester.getDynamicConfig!(actionInfo)
+    expect(config).to.deep.equal(actionInfo.rawConfig)
+  })
 })
-
-
-

--- a/test/mocha/private-package-json.ts
+++ b/test/mocha/private-package-json.ts
@@ -1,23 +1,24 @@
 const packageJson = {
-    main: './dist/index.js',
-    directories: {
-        test: 'test'
-    },
-    scripts: {
-        build: 'tsc -d',
-        test:
-            'mocha --require babel-core/register --require setup.js --require source-map-support/register ./**/*.spec.js',
-        clean: 'rimraf ./dist/*'
-    },
-    devDependencies: {
-        chai: '^4.1.2',
-        mocha: '^5.2.0',
-        rimraf: '^2.6.2',
-        'source-map-support': '^0.5.6',
-        'babel-core': '^6.26.3',
-        'babel-preset-env': '^1.6.1'
-    },
-    dependencies: {}
+  main: './dist/index.js',
+  directories: {
+    test: 'test'
+  },
+  scripts: {
+    build: 'tsc -d',
+    test:
+      'mocha --require babel-core/register --require setup.js ' +
+      '--require source-map-support/register ./**/*.spec.js',
+    clean: 'rimraf ./dist/*'
+  },
+  devDependencies: {
+    chai: '^4.1.2',
+    mocha: '^5.2.0',
+    rimraf: '^2.6.2',
+    'source-map-support': '^0.5.6',
+    'babel-core': '^6.26.3',
+    'babel-preset-env': '^1.6.1'
+  },
+  dependencies: {}
 }
 
 export default packageJson

--- a/test/utils/configuration.spec.ts
+++ b/test/utils/configuration.spec.ts
@@ -1,141 +1,207 @@
-import { setup, generatePackageJson, createExtensionInfo } from '../envs-test-utils'
+import {
+  setup,
+  generatePackageJson,
+  createExtensionInfo
+} from '../envs-test-utils'
 import path from 'path'
-import {findConfiguration, FindStrategy , defaultGetBy} from '../../src/find-configuration'
-import { expect, use } from 'chai';
+import {
+  findConfiguration,
+  FindStrategy,
+  defaultGetBy
+} from '../../src/find-configuration'
+import { expect, use } from 'chai'
 import subset from 'chai-subset'
-import {ignoreList} from '../babel/ignore-list'
+import { ignoreList } from '../babel/ignore-list'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
-import fs  from 'fs-extra'
+import fs from 'fs-extra'
 
 use(subset)
 use(sinonChai)
-describe('configuration', function() {
-    const configPackageFixturePath = path.resolve( __dirname, 'fixture-config-package')
-    const configFileFixturePath = path.resolve( __dirname, 'fixture-config-bit-file')
-    const configBitRawFixturePath = path.resolve( __dirname, 'fixture-config-bit-raw')
-    let packageJson = {
-        babel: {
-            presets: ['latest', 'react'],
-            sourceMaps: true,
-            ast: false,
-            minified: false,
-            plugins: [
-                'babel-plugin-inline-react-svg',
-                ['transform-object-rest-spread', { useBuiltIns: true }],
-                'transform-decorators-legacy',
-                'transform-object-entries',
-                'object-values-to-object-keys',
-                'transform-export-extensions',
-                'transform-class-properties',
-                'transform-async-to-generator',
-                ['transform-react-jsx', { useBuiltIns: true }],
-                ['transform-regenerator', { async: false }]
-            ],
-            ignore: ['**/*.svg']
-        }
+describe('configuration', function () {
+  const configPackageFixturePath = path.resolve(
+    __dirname,
+    'fixture-config-package'
+  )
+  const configFileFixturePath = path.resolve(
+    __dirname,
+    'fixture-config-bit-file'
+  )
+  const configBitRawFixturePath = path.resolve(
+    __dirname,
+    'fixture-config-bit-raw'
+  )
+  let packageJson = {
+    babel: {
+      presets: ['latest', 'react'],
+      sourceMaps: true,
+      ast: false,
+      minified: false,
+      plugins: [
+        'babel-plugin-inline-react-svg',
+        ['transform-object-rest-spread', { useBuiltIns: true }],
+        'transform-decorators-legacy',
+        'transform-object-entries',
+        'object-values-to-object-keys',
+        'transform-export-extensions',
+        'transform-class-properties',
+        'transform-async-to-generator',
+        ['transform-react-jsx', { useBuiltIns: true }],
+        ['transform-regenerator', { async: false }]
+      ],
+      ignore: ['**/*.svg']
     }
-    before(function() {
-        generatePackageJson({
-            [configPackageFixturePath]: packageJson,
-            [configFileFixturePath]: packageJson,
-            [configBitRawFixturePath]: {}
-        })
-        setup(this, [configPackageFixturePath, configFileFixturePath])
+  }
+  before(function () {
+    generatePackageJson({
+      [configPackageFixturePath]: packageJson,
+      [configFileFixturePath]: packageJson,
+      [configBitRawFixturePath]: {}
+    })
+    setup(this, [configPackageFixturePath, configFileFixturePath])
+  })
+
+  it('should be found in package.json', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configPackageFixturePath,
+      ignoreList
+    )
+    const findOptions = { pjKeyName: 'babel', fileName: '' }
+    const config = findConfiguration(info, findOptions)
+    expect(config.config[findOptions.pjKeyName]).to.deep.equal(
+      (packageJson as any)[findOptions.pjKeyName]
+    )
+    expect(!!config.save).to.equal(true)
+  })
+
+  it('should read from raw config bit.json', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configBitRawFixturePath,
+      ignoreList
+    )
+    const findOptions = { pjKeyName: 'babel', fileName: '.babelrc' }
+    const rawConfig = { [findOptions.pjKeyName]: { lol: 'wow' } }
+    info['rawConfig'] = rawConfig
+    const config = findConfiguration(info, findOptions)
+    expect(config.config).to.deep.equal(rawConfig[findOptions.pjKeyName])
+    expect(!!config.save).to.equal(false)
+  })
+
+  it('should fallback to default config', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configBitRawFixturePath,
+      ignoreList
+    )
+    const config = findConfiguration(info, {
+      pjKeyName: 'babel',
+      fileName: '.babelrc'
+    })
+    expect(config.config).to.deep.equal({})
+    expect(!!config.save).to.equal(false)
+  })
+
+  it('should always override with raw', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configFileFixturePath,
+      ignoreList
+    )
+    const findOptions = { pjKeyName: 'babel', fileName: '.babelrc' }
+    const rawConfig = { [findOptions.pjKeyName]: { ast: 'true' } }
+    info['rawConfig'] = rawConfig
+    const config = findConfiguration(info, findOptions)
+    const subset = fs.readJSONSync(
+      path.resolve(configFileFixturePath, '.babelrc')
+    )
+    delete subset.ast
+    expect(config.config).to.containSubset(subset)
+    expect(config.config).to.containSubset(rawConfig[findOptions.pjKeyName])
+  })
+
+  it('should support dynamic strategy order', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configBitRawFixturePath,
+      ignoreList
+    )
+    const strategyRegistry: { [k: string]: sinon.SinonSpy } = {
+      [FindStrategy.default]: sinon.spy(),
+      [FindStrategy.pjKeyName]: sinon.spy(),
+      [FindStrategy.fileName]: sinon.spy(),
+      [FindStrategy.raw]: sinon.spy(defaultGetBy.raw)
+    }
+    const config = findConfiguration(
+      info,
+      { pjKeyName: 'babel', fileName: '.babelrc', strategy: [] },
+      strategyRegistry
+    )
+    expect(config.config).to.deep.equal({})
+    Object.keys(strategyRegistry).forEach((element: string) => {
+      return element === FindStrategy.raw
+        ? expect(strategyRegistry[element]).to.be.calledOnce
+        : expect(strategyRegistry[element]).not.be.called
+    })
+  })
+
+  it('should support dynamicConfig', function () {
+    const info = createExtensionInfo(
+      '.babelrc',
+      configBitRawFixturePath,
+      ignoreList
+    )
+    const findOptions = { pjKeyName: 'babel', fileName: '.babelrc' }
+    const dynamicConfig = { [findOptions.pjKeyName]: { lol: 'wow' } }
+    info['dynamicConfig'] = dynamicConfig
+    const config = findConfiguration(info, findOptions)
+    // @ts-ignore
+    expect(config.config[findOptions.pjKeyName]).to.deep.equal(
+      dynamicConfig[findOptions.pjKeyName]
+    )
+    expect(!!config.save).to.equal(false)
+  })
+
+  describe('by file', function () {
+    it('should should support happy flow', function () {
+      const info = createExtensionInfo(
+        '.babelrc',
+        configFileFixturePath,
+        ignoreList
+      )
+      const config = findConfiguration(info, {
+        pjKeyName: 'babel',
+        fileName: '.babelrc'
+      })
+      expect(config.config).to.deep.equal(
+        fs.readJSONSync(path.resolve(configFileFixturePath, '.babelrc'))
+      )
+      expect(!!config.save).to.equal(false)
     })
 
-    it('should be found in package.json', function() {
-        const info = createExtensionInfo('.babelrc', configPackageFixturePath, ignoreList )
-        const findOptions = {pjKeyName:'babel', fileName:''}
-        const config = findConfiguration(info, findOptions)
-        expect(config.config[findOptions.pjKeyName]).to.deep.equal((packageJson as any)[findOptions.pjKeyName])
-        expect(config.save).to.be.true
+    it('should support default file paths', function () {
+      const info = createExtensionInfo(
+        '.lol',
+        configFileFixturePath,
+        ignoreList
+      )
+      const findOptions = {
+        pjKeyName: 'babel',
+        fileName: '.babelrc',
+        defaultFilePaths: ['./.babelrc']
+      }
+      let config = findConfiguration(info, findOptions).config
+      expect(config).to.deep.equal(
+        fs.readJsonSync(
+          path.resolve(__dirname, './fixture-config-bit-file/.babelrc')
+        )
+      )
     })
-
-    it('should read from raw config bit.json', function() {
-        const info = createExtensionInfo('.babelrc', configBitRawFixturePath, ignoreList )
-        const findOptions = {pjKeyName:'babel', fileName: '.babelrc'}
-        const rawConfig = {[findOptions.pjKeyName]:{'lol':'wow'}}
-        info['rawConfig'] = rawConfig
-        const config = findConfiguration(info, findOptions)
-        expect(config.config).to.deep.equal(rawConfig[findOptions.pjKeyName])
-        expect(config.save).to.be.false
-    })
-
-    it('should fallback to default config', function() {
-        const info = createExtensionInfo('.babelrc', configBitRawFixturePath, ignoreList )
-        const config = findConfiguration(info, {pjKeyName:'babel', fileName: '.babelrc'})
-        expect(config.config).to.deep.equal({})
-        expect(config.save).to.be.false
-    })
-
-    it('should always override with raw', function (){
-        const info = createExtensionInfo('.babelrc', configFileFixturePath, ignoreList )
-        const findOptions = {pjKeyName:'babel', fileName: '.babelrc'}
-        const rawConfig = {[findOptions.pjKeyName]:{'ast':'true'}}
-        info['rawConfig'] = rawConfig
-        const config = findConfiguration(info, findOptions)
-        const subset = fs.readJSONSync(path.resolve(configFileFixturePath, '.babelrc'))
-        delete subset.ast
-        expect(config.config).to.containSubset(subset)
-        expect(config.config).to.containSubset(rawConfig[findOptions.pjKeyName])
-    })
-
-    it('should support dynamic strategy order', function () {
-        const info = createExtensionInfo('.babelrc', configBitRawFixturePath, ignoreList )
-        const strategyRegistry:{[k:string]:sinon.SinonSpy} = {
-            [FindStrategy.default]: sinon.spy(),
-            [FindStrategy.pjKeyName]: sinon.spy(),
-            [FindStrategy.fileName]: sinon.spy(),
-            [FindStrategy.raw]: sinon.spy(defaultGetBy.raw)
-        }
-        const config = findConfiguration(info, {pjKeyName:'babel', fileName: '.babelrc', strategy: []}, strategyRegistry)
-        expect(config.config).to.deep.equal({})
-        Object.keys(strategyRegistry).forEach((element:string) => {
-            return element === FindStrategy.raw ?
-                expect(strategyRegistry[element]).to.be.calledOnce :
-                expect(strategyRegistry[element]).not.be.called
-        })
-    })
-
-    it('should support dynamicConfig', function(){
-        const info = createExtensionInfo('.babelrc', configBitRawFixturePath, ignoreList )
-        const findOptions = {pjKeyName:'babel', fileName: '.babelrc'}
-        const dynamicConfig = {[findOptions.pjKeyName]:{'lol':'wow'}}
-        info['dynamicConfig'] = dynamicConfig
-        const config = findConfiguration(info, findOptions)
-        //@ts-ignore
-        expect(config.config[findOptions.pjKeyName]).to.deep.equal(dynamicConfig[findOptions.pjKeyName])
-        expect(config.save).to.be.false
-    })
-
-    describe('by file', function(){
-        it('should should support happy flow', function(){
-            const info = createExtensionInfo('.babelrc', configFileFixturePath, ignoreList )
-            const config = findConfiguration(info, {pjKeyName:'babel', fileName: '.babelrc'})
-            expect(config.config).to.deep.equal(fs.readJSONSync(path.resolve(configFileFixturePath, '.babelrc')))
-            expect(config.save).to.be.false
-        })
-
-        it('should support default file paths', function() {
-            const info = createExtensionInfo('.lol', configFileFixturePath, ignoreList )
-            const findOptions = {
-                pjKeyName: 'babel',
-                fileName: '.babelrc',
-                defaultFilePaths: ['./.babelrc']
-
-            }
-            let config = findConfiguration(info, findOptions ).config
-            expect(config).to.deep.equal(fs.readJsonSync(path.resolve(__dirname, './fixture-config-bit-file/.babelrc')))
-
-            // expect(config.config).to.deep.equal(fs.readJSONSync(path.resolve(configFileFixturePath, '.babelrc')))
-            // expect(config.save).to.be.true
-        })
-
-    })
-    xit('should support non standard json file', function(){})
-
-
+  })
+  xit('should support non standard json file', function () {
+      // TBD
+  })
 })
 
 /***

--- a/test/webpack/fixture/add.ts
+++ b/test/webpack/fixture/add.ts
@@ -1,3 +1,3 @@
-export function add(a:number, b:number){
-    return a + b
+export function add (a: number, b: number) {
+  return a + b
 }

--- a/test/webpack/fixture/index.ts
+++ b/test/webpack/fixture/index.ts
@@ -1,7 +1,6 @@
-import {add} from './add'
-import {sub} from './sub'
+import { add } from './add'
+import { sub } from './sub'
 
-export function run() {
-    return add(sub(1,2),1)
+export function run () {
+  return add(sub(1, 2), 1)
 }
-

--- a/test/webpack/fixture/main.spec.ts
+++ b/test/webpack/fixture/main.spec.ts
@@ -1,6 +1,6 @@
-import {add} from './add'
-import {expect} from 'chai'
+import { add } from './add'
+import { expect } from 'chai'
 
-describe('webpack test bundle', function (){
-    expect(add(1,1)).to.equal(2)
+describe('webpack test bundle', function () {
+  expect(add(1, 1)).to.equal(2)
 })

--- a/test/webpack/fixture/sub.ts
+++ b/test/webpack/fixture/sub.ts
@@ -1,3 +1,3 @@
-export function sub(a:number, b:number){
-    return a - b
+export function sub (a: number, b: number) {
+  return a - b
 }

--- a/test/webpack/private-package-json-babel.ts
+++ b/test/webpack/private-package-json-babel.ts
@@ -1,27 +1,27 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        'css-loader': '^1.0.0',
-        'file-loader': '^1.1.11',
-        rimraf: '^2.6.2',
-        'style-loader': '^0.21.0',
-        'url-loader': '^1.0.1',
-        'webpack-cli': '^3.0.8',
-        'babel-plugin-transform-object-rest-spread': '^6.26.0',
-        'babel-plugin-transform-async-to-module-method': '^6.24.1',
-        'babel-preset-env': '^1.6.1',
-        'babel-preset-latest': '^6.24.1'
-    },
-    scripts: {
-        build: 'webpack-cli --progress',
-        clean: 'rimraf dist/*'
-    },
-    dependencies: {
-        '@types/react': '^16.4.6',
-        'babel-loader': '^7.1.5',
-        react: '^16.4.1',
-        'react-dom': '^16.4.1'
-    }
+  main: './dist/index',
+  devDependencies: {
+    'css-loader': '^1.0.0',
+    'file-loader': '^1.1.11',
+    rimraf: '^2.6.2',
+    'style-loader': '^0.21.0',
+    'url-loader': '^1.0.1',
+    'webpack-cli': '^3.0.8',
+    'babel-plugin-transform-object-rest-spread': '^6.26.0',
+    'babel-plugin-transform-async-to-module-method': '^6.24.1',
+    'babel-preset-env': '^1.6.1',
+    'babel-preset-latest': '^6.24.1'
+  },
+  scripts: {
+    build: 'webpack-cli --progress',
+    clean: 'rimraf dist/*'
+  },
+  dependencies: {
+    '@types/react': '^16.4.6',
+    'babel-loader': '^7.1.5',
+    react: '^16.4.1',
+    'react-dom': '^16.4.1'
+  }
 }
 
 export default packageJson

--- a/test/webpack/private-package-json-e2e.ts
+++ b/test/webpack/private-package-json-e2e.ts
@@ -1,21 +1,20 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        'css-loader': '1.0.0',
-        'file-loader': '1.1.11',
-        rimraf: '2.6.2',
-        'style-loader': '0.21.0',
-        'babel-loader': '^8.0.4',
-        'url-loader': '1.0.1',
-        'webpack-cli': '3.0.8',
-        typescript: '2.7.1'
-    },
-    scripts: {
-        build: 'webpack-cli --progress',
-        clean: 'rimraf dist/*'
-    },
-    dependencies: {
-    }
+  main: './dist/index',
+  devDependencies: {
+    'css-loader': '1.0.0',
+    'file-loader': '1.1.11',
+    rimraf: '2.6.2',
+    'style-loader': '0.21.0',
+    'babel-loader': '^8.0.4',
+    'url-loader': '1.0.1',
+    'webpack-cli': '3.0.8',
+    typescript: '2.7.1'
+  },
+  scripts: {
+    build: 'webpack-cli --progress',
+    clean: 'rimraf dist/*'
+  },
+  dependencies: {}
 }
 
 export default packageJson

--- a/test/webpack/private-package-json.ts
+++ b/test/webpack/private-package-json.ts
@@ -1,25 +1,25 @@
 const packageJson = {
-    main: './dist/index',
-    devDependencies: {
-        'css-loader': '^1.0.0',
-        'file-loader': '^1.1.11',
-        rimraf: '^2.6.2',
-        'style-loader': '^0.21.0',
-        'ts-loader': '^4.4.2',
-        'url-loader': '^1.0.1',
-        'webpack-cli': '^3.0.8'
-    },
-    scripts: {
-        build: 'webpack-cli --progress',
-        clean: 'rimraf dist/*'
-    },
-    dependencies: {
-        chai: '^4.1.2',
-        react: '^16.4.1',
-        'react-dom': '^16.4.1',
-        '@types/react': '^16.4.8',
-        '@types/react-dom': '^16.0.7'
-    }
+  main: './dist/index',
+  devDependencies: {
+    'css-loader': '^1.0.0',
+    'file-loader': '^1.1.11',
+    rimraf: '^2.6.2',
+    'style-loader': '^0.21.0',
+    'ts-loader': '^4.4.2',
+    'url-loader': '^1.0.1',
+    'webpack-cli': '^3.0.8'
+  },
+  scripts: {
+    build: 'webpack-cli --progress',
+    clean: 'rimraf dist/*'
+  },
+  dependencies: {
+    chai: '^4.1.2',
+    react: '^16.4.1',
+    'react-dom': '^16.4.1',
+    '@types/react': '^16.4.8',
+    '@types/react-dom': '^16.0.7'
+  }
 }
 
 export default packageJson

--- a/test/webpack/webpack.e2e.ts
+++ b/test/webpack/webpack.e2e.ts
@@ -1,31 +1,34 @@
-import {expect} from 'chai'
+import { expect } from 'chai'
 import path from 'path'
 import fs from 'fs-extra'
-import {e2eHelper} from '../e2e-helper'
-import { setup, generatePackageJson } from '../envs-test-utils';
+import { e2eHelper } from '../e2e-helper'
+import { setup, generatePackageJson } from '../envs-test-utils'
 import packageJSON from './private-package-json-e2e'
+import _eval from 'eval'
 
-describe('webpack', function() {
-    const baseFixturePath = path.resolve(__dirname, './fixture-e2e')
-    const compilerPath = path.resolve(__dirname, '../../dist/src/webpack')
-    const helper = e2eHelper({
-        baseFixturePath,
-        mainFile:'index.js',
-        compilerName:'webpack',
-        confName:['webpack.config.js', '.babelrc'],
-        compilerPath
-    })
-    before(function() {
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
-        this.timeout(1000 * 1000)
-        helper.before()
-    })
-    after(function() {
-        helper.after()
-    })
-    it('bit should bundle a component with webpack meta bundler', function() {
-        const bundle = fs.readFileSync(path.resolve(baseFixturePath, 'dist/main.bundle.js')).toString()
-        expect(eval(bundle).run()).to.equal(0)
-    })
+describe('webpack', function () {
+  const baseFixturePath = path.resolve(__dirname, './fixture-e2e')
+  const compilerPath = path.resolve(__dirname, '../../dist/src/webpack')
+  const helper = e2eHelper({
+    baseFixturePath,
+    mainFile: 'index.js',
+    compilerName: 'webpack',
+    confName: ['webpack.config.js', '.babelrc'],
+    compilerPath
+  })
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+    this.timeout(1000 * 1000)
+    helper.before()
+  })
+  after(function () {
+    helper.after()
+  })
+  it('bit should bundle a component with webpack meta bundler', function () {
+    const bundle = fs
+      .readFileSync(path.resolve(baseFixturePath, 'dist/main.bundle.js'))
+      .toString()
+    expect(_eval(bundle).run()).to.equal(0)
+  })
 })

--- a/test/webpack/webpack.spec.ts
+++ b/test/webpack/webpack.spec.ts
@@ -1,176 +1,201 @@
-import {expect} from 'chai'
-import {CreateWebpackCompiler} from '../../src/webpack'
-import {CompilerExtension, ExtensionApiOptions} from '../../src/env-utils'
-import {createApi, createConfigFile, createFiles, setup, generatePackageJson} from '../envs-test-utils'
-import {getVersion} from '../../src/env-utils'
+import { expect } from 'chai'
+import { CreateWebpackCompiler } from '../../src/webpack'
+import {
+  CompilerExtension,
+  ExtensionApiOptions,
+  getVersion
+} from '../../src/env-utils'
+import {
+  createApi,
+  createConfigFile,
+  createFiles,
+  setup,
+  generatePackageJson
+} from '../envs-test-utils'
 import path from 'path'
 import packageJSON from './private-package-json'
 import packageJSONBabel from './private-package-json-babel'
+import _eval from 'eval'
 
 const baseFixturePath = path.resolve(__dirname, './fixture')
 
 describe('Webpack', function () {
-    before(function(){
-        generatePackageJson({[baseFixturePath]:packageJSON})
-        setup(this, [baseFixturePath])
+  before(function () {
+    generatePackageJson({ [baseFixturePath]: packageJSON })
+    setup(this, [baseFixturePath])
+  })
+  it('init', function () {
+    const compiler = CreateWebpackCompiler()
+    let options = compiler.init({
+      api: createApi()
     })
-    it('init', function (){
-        const compiler = CreateWebpackCompiler()
-        let options = compiler.init({
-            api: createApi()
-        })
-        expect(!!compiler.logger).to.be.true
-        expect(options.write).to.be.true
+    expect(!!compiler.logger).to.equal(true)
+    expect(!!options.write).to.equal(true)
+  })
+  describe('action', function () {
+    this.timeout(5000 * 5)
+    let compiler: CompilerExtension | null = null
+    let actionInfo: ExtensionApiOptions | null = null
+    let config = null
+    let cwd = ''
+    before(function () {
+      compiler = CreateWebpackCompiler()
+      const files = createFiles(baseFixturePath, ['.gitignore'])
+      config = createConfigFile(baseFixturePath)
+      actionInfo = {
+        files,
+        configFiles: [config],
+        context: {
+          componentDir: '',
+          componentObject: {
+            mainFile: 'index.ts'
+          },
+          rootDistDir: path.resolve(baseFixturePath, './dist')
+        }
+      }
+      compiler.init({ api: createApi() })
     })
-    describe('action', function() {
-        this.timeout(5000 * 5)
-        let compiler:CompilerExtension|null = null
-        let actionInfo:ExtensionApiOptions|null = null
-        let config = null
-        let cwd = ''
-        before(function(){
-            compiler = CreateWebpackCompiler()
-            const files = createFiles(baseFixturePath, ['.gitignore'])
-            config = createConfigFile(baseFixturePath)
-            actionInfo = {
-                files,
-                configFiles:[config],
-                context: {
-                    componentDir: '',
-                    componentObject: {
-                        mainFile: 'index.ts'
-                    },
-                    rootDistDir: path.resolve(baseFixturePath, './dist')
-                }
-            }
-            compiler!.init({api: createApi()})
-
-        })
-        beforeEach(function(){
-            cwd = process.cwd()
-            process.chdir(baseFixturePath)
-        })
-        afterEach(function(){
-            process.chdir(cwd)
-        })
-        it('basic bundling', function() {
-            return compiler!.action(actionInfo!).then(function(assets) {
-                const lib = eval(assets.files[0].contents!.toString())
-                expect(lib.run()).to.equal(0)
-            })
-        })
-
-        it('with dynamic configuration', function() {
-            const config = compiler!.getDynamicConfig!(actionInfo!)
-            expect(config).to.deep.equal({})
-        })
-
-        it('should support filename without ending', function() {
-            const configName = 'webpack2.config.js'
-            const beforeChanges = actionInfo!.configFiles
-            const compiler = CreateWebpackCompiler(configName)
-            compiler.init({api: createApi()})
-            actionInfo!.configFiles = [createConfigFile(baseFixturePath, configName)]
-            return compiler!.action(actionInfo!).then(function(assets) {
-                actionInfo!.configFiles = beforeChanges
-                const lib = eval(assets.files[0].contents!.toString())
-                expect(lib.run()).to.equal(0)
-            })
-        })
-
-        it('should return multiple assets', function() {
-            const configName = 'webpack3.config.js'
-            const beforeChanges = actionInfo!.configFiles
-            const compiler = CreateWebpackCompiler(configName)
-            compiler.init({api: createApi()})
-            actionInfo!.configFiles = [createConfigFile(baseFixturePath, configName)]
-            return compiler!.action(actionInfo!).then(function(assets) {
-                actionInfo!.configFiles = beforeChanges
-                expect(assets.files.length).to.be.greaterThan(1)
-            })
-        })
-        it('should keep entires test or ends with _test', function () {
-            const configName = 'webpack4.config.js'
-            const compiler:CompilerExtension = CreateWebpackCompiler(configName)
-            const config = createConfigFile(baseFixturePath, configName)
-            const files = createFiles(baseFixturePath, ['.gitignore'])
-            const actionInfo:ExtensionApiOptions = {
-                files,
-                configFiles:[config],
-                context: {
-                    componentDir: '',
-                    componentObject: {
-                        mainFile: 'index.ts'
-                    },
-                    rootDistDir: path.resolve(baseFixturePath, './dist')
-                }
-            }
-            compiler!.init({api: createApi()})
-            return compiler.action(actionInfo).then(function (assets){
-                expect(assets.files.some((file)=>file.basename === 'test.bundle.js' )).to.be.true
-                expect(assets.files.some((file)=>file.basename ==='another_test.bundle.js')).to.be.true
-            })
-        })
+    beforeEach(function () {
+      cwd = process.cwd()
+      process.chdir(baseFixturePath)
+    })
+    afterEach(function () {
+      process.chdir(cwd)
+    })
+    it('basic bundling', function () {
+      return compiler!.action(actionInfo!).then(function (assets) {
+        const lib = _eval(assets.files[0].contents!.toString())
+        expect(lib.run()).to.equal(0)
+      })
     })
 
-
-    describe('getDynamicPackageDependencies', function() {
-        let compiler:CompilerExtension|null = null
-        let config:any = null
-        let context:any =  null
-        let packageJSON:any =  null
-        before('setting up test compiler', function() {
-            compiler = CreateWebpackCompiler()
-            config = createConfigFile(baseFixturePath)
-            context = {
-                componentDir: baseFixturePath
-            }
-            packageJSON = require(path.resolve(baseFixturePath, './package.json'))
-
-        })
-        it('should support use as string', function() {
-            const result = compiler!.getDynamicPackageDependencies({configFiles:[config], context:context})
-            expect(result).to.contain({
-                'ts-loader': getVersion(packageJSON, 'ts-loader')
-            })
-        })
-        it('should support use as array', function() {
-            const result = compiler!.getDynamicPackageDependencies({configFiles:[config], context:context})
-            expect(result).to.contain({
-                'style-loader': getVersion(packageJSON, 'style-loader'),
-                'css-loader': getVersion(packageJSON, 'css-loader')
-            })
-        })
-        it('should support loader as string', function() {
-            const result = compiler!.getDynamicPackageDependencies({configFiles:[config], context:context})
-            expect(result).to.contain({
-                'url-loader':getVersion(packageJSON, 'url-loader')
-            })
-        })
-        it('should support babel-loader .babelrc file', function (){
-            const fixturePath = path.resolve(__dirname, './fixture-babel')
-            generatePackageJson({[fixturePath]:packageJSONBabel})
-            const configName = 'my-private-config.js'
-            const compiler = CreateWebpackCompiler(configName)
-            const configs = [createConfigFile(fixturePath,configName)!, createConfigFile(fixturePath, 'my-private-rc')!]
-            const packageJSON = require(path.resolve(fixturePath, './package.json'))
-
-            const context = {
-                componentDir: fixturePath
-            }
-            compiler.init({api: createApi()})
-            const result = compiler.getDynamicPackageDependencies({configFiles: configs, context: context}, 'my-private-rc')
-
-            const presetEnv = 'babel-preset-env'
-            const restPlugin = 'babel-plugin-transform-object-rest-spread'
-            const asyncPlugin = 'babel-plugin-transform-async-to-module-method'
-            expect(result).to.contain({
-                [presetEnv]: getVersion(packageJSON, presetEnv),
-                [restPlugin]: getVersion(packageJSON, restPlugin),
-                [asyncPlugin]: getVersion(packageJSON, asyncPlugin)
-            })
-        })
+    it('with dynamic configuration', function () {
+      const config = compiler!.getDynamicConfig!(actionInfo!)
+      expect(config).to.deep.equal({})
     })
+
+    it('should support filename without ending', function () {
+      const configName = 'webpack2.config.js'
+      const beforeChanges = actionInfo!.configFiles
+      const compiler = CreateWebpackCompiler(configName)
+      compiler.init({ api: createApi() })
+      actionInfo!.configFiles = [createConfigFile(baseFixturePath, configName)]
+      return compiler.action(actionInfo!).then(function (assets) {
+        actionInfo!.configFiles = beforeChanges
+        const lib = _eval(assets.files[0].contents!.toString())
+        expect(lib.run()).to.equal(0)
+      })
+    })
+
+    it('should return multiple assets', function () {
+      const configName = 'webpack3.config.js'
+      const beforeChanges = actionInfo!.configFiles
+      const compiler = CreateWebpackCompiler(configName)
+      compiler.init({ api: createApi() })
+      actionInfo!.configFiles = [createConfigFile(baseFixturePath, configName)]
+      // return compiler!.action(actionInfo!).then(function (assets) {
+      return compiler.action(actionInfo!).then(function (assets) {
+        actionInfo!.configFiles = beforeChanges
+        expect(assets.files.length).to.be.greaterThan(1)
+      })
+    })
+    it('should keep entires test or ends with _test', function () {
+      const configName = 'webpack4.config.js'
+      const compiler: CompilerExtension = CreateWebpackCompiler(configName)
+      const config = createConfigFile(baseFixturePath, configName)
+      const files = createFiles(baseFixturePath, ['.gitignore'])
+      const actionInfo: ExtensionApiOptions = {
+        files,
+        configFiles: [config],
+        context: {
+          componentDir: '',
+          componentObject: {
+            mainFile: 'index.ts'
+          },
+          rootDistDir: path.resolve(baseFixturePath, './dist')
+        }
+      }
+      compiler.init({ api: createApi() })
+      return compiler.action(actionInfo).then(function (assets) {
+        expect(
+          assets.files.some(file => file.basename === 'test.bundle.js')
+        ).to.equal(true)
+        expect(
+          assets.files.some(file => file.basename === 'another_test.bundle.js')
+        ).to.equal(true)
+      })
+    })
+  })
+
+  describe('getDynamicPackageDependencies', function () {
+    let compiler: CompilerExtension | null = null
+    let config: any = null
+    let context: any = null
+    let packageJSON: any = null
+    before('setting up test compiler', function () {
+      compiler = CreateWebpackCompiler()
+      config = createConfigFile(baseFixturePath)
+      context = {
+        componentDir: baseFixturePath
+      }
+      packageJSON = require(path.resolve(baseFixturePath, './package.json'))
+    })
+    it('should support use as string', function () {
+      const result = compiler!.getDynamicPackageDependencies({
+        configFiles: [config],
+        context: context
+      })
+      expect(result).to.contain({
+        'ts-loader': getVersion(packageJSON, 'ts-loader')
+      })
+    })
+    it('should support use as array', function () {
+      const result = compiler!.getDynamicPackageDependencies({
+        configFiles: [config],
+        context: context
+      })
+      expect(result).to.contain({
+        'style-loader': getVersion(packageJSON, 'style-loader'),
+        'css-loader': getVersion(packageJSON, 'css-loader')
+      })
+    })
+    it('should support loader as string', function () {
+      const result = compiler!.getDynamicPackageDependencies({
+        configFiles: [config],
+        context: context
+      })
+      expect(result).to.contain({
+        'url-loader': getVersion(packageJSON, 'url-loader')
+      })
+    })
+    it('should support babel-loader .babelrc file', function () {
+      const fixturePath = path.resolve(__dirname, './fixture-babel')
+      generatePackageJson({ [fixturePath]: packageJSONBabel })
+      const configName = 'my-private-config.js'
+      const compiler = CreateWebpackCompiler(configName)
+      const configs = [
+        createConfigFile(fixturePath, configName),
+        createConfigFile(fixturePath, 'my-private-rc')
+      ]
+      const packageJSON = require(path.resolve(fixturePath, './package.json'))
+
+      const context = {
+        componentDir: fixturePath
+      }
+      compiler.init({ api: createApi() })
+      const result = compiler.getDynamicPackageDependencies(
+        { configFiles: configs, context: context },
+        'my-private-rc'
+      )
+
+      const presetEnv = 'babel-preset-env'
+      const restPlugin = 'babel-plugin-transform-object-rest-spread'
+      const asyncPlugin = 'babel-plugin-transform-async-to-module-method'
+      expect(result).to.contain({
+        [presetEnv]: getVersion(packageJSON, presetEnv),
+        [restPlugin]: getVersion(packageJSON, restPlugin),
+        [asyncPlugin]: getVersion(packageJSON, asyncPlugin)
+      })
+    })
+  })
 })
-
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,23 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-     "lib": ["dom", "es2015"],                             /* Specify library files to be included in the compilation. */
+    "target":
+      "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module":
+      "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "dom",
+      "es2015"
+    ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "jsx":
+      "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -21,44 +27,41 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,              /* Enable strict null checks. */
-    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
 
     /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
-    "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution":
+      "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": ["./node_modules/@types", "./custom-types"],  /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
+    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": [
-    "dist",
-    "node_modules",
-    "test/webpack/fixture"
-  ]
+  "exclude": ["dist", "node_modules", "test/webpack/fixture"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,9 @@
+{
+  "defaultSeverity": "error",
+  "extends": "tslint-config-standard",
+  "jsRules": {},
+  "rules": {
+    "max-line-length": [true, 80]
+  },
+  "rulesDirectory": []
+}


### PR DESCRIPTION
Hey @qballer - following our conversation, this PR creates a linting infra.

#### things added in this PR
1. tslint to check linting
2. standardjs configuration for tslint
3. enforcing an 80 character line limit
4. updating the .editorconfig file to match these rules

#### what has changed
1. `npm run lint` will run tslint on the project, making sure everything is on the up and up.
2. `npm test` has been moved to `npm test-only`, now running `npm test` will first check linting, and only if all is well move on to test. While working on the project, one can use `npm run test-only` in order not to break their workflow, and fix linting mistakes before pushing.

#### issues found
1. There were a few places where `eval` was used directly. Since the eval package (using the node vm) has already been installed on the project, I changed them to use it.
2. Some assertions were unnecessary and tslint complained about them (eg. `typeof <thing> === string` where `thing` is declared to have the mandatory type of `string` before them in the same block. I removed them - tests still pass.
3. The mocha `expect(<thing>).to.be.true` is something standard does not like. Reading the rationale, this made sense to me, so I changed them to `expect(!!<thing>).to.equal(true)` to read more: https://github.com/moll/js-must#asserting-on-property-access (in a nutshell, since mocha does not have assertion counting, if I accidentally change them to `expect(<thing>).to.be.truee`, my tests will still pass. Using a getter as an assertion is a little meh in js, I reckon.

Sorry for the big diff, most of it is 4 spaces => 2 spaces and semicolon-extraction.

