### PR TITLE
fix(mocha): support global requires in mocha.opts

### DIFF
--- a/src/mocha/configuration-parser.ts
+++ b/src/mocha/configuration-parser.ts
@@ -36,10 +36,11 @@ const addDotSlashPrefIfAbsent = (file: string) => file.replace(/^\.\/|^/, './')
 
 const throwOnMissingRequires = (parser: any, info: ExtensionApiOptions) => {
   const externalFiles = parser.require ? [parser.require] : []
+  const localExternalFiles = externalFiles.filter(f => f.startsWith('./'))
   const configFiles = info.configFiles.map(f => f.relative)
-  const missingConfigFiles = externalFiles.filter((f: string) => {
+  const missingConfigFiles = localExternalFiles.filter((f: string) => {
     return !configFiles.find(
-      cFile => addDotSlashPrefIfAbsent(cFile) === addDotSlashPrefIfAbsent(f)
+      cFile => addDotSlashPrefIfAbsent(cFile) === f
     )
   })
   if (missingConfigFiles.length > 0) {

--- a/src/mocha/mocha.ts
+++ b/src/mocha/mocha.ts
@@ -25,14 +25,22 @@ export function CreateMochaTester (): TesterExtension {
       }
     },
     getDynamicConfig: function (info: ActionTesterOptions) {
-      let config = mochaFindConfiguration(info)
+      const config = mochaFindConfiguration(info)
       const rawConfigFilesRequire = _get(info, 'rawConfig.filesRequire', [])
-      const filesRequire =
+      const rawConfigRequire = _get(info, 'rawConfig.require', [])
+      const configuredRequire =
         config.save && config.config && config.config.mochaRequire
-          ? rawConfigFilesRequire.concat(config.config.mochaRequire)
-          : rawConfigFilesRequire
+      const isFileRequire =
+        configuredRequire && configuredRequire.startsWith('./')
       return config.save
-        ? Object.assign({}, config.config, { filesRequire })
+        ? Object.assign({}, config.config, {
+          filesRequire: configuredRequire && isFileRequire
+            ? rawConfigFilesRequire.concat(configuredRequire)
+            : rawConfigFilesRequire,
+          require: configuredRequire && !isFileRequire
+            ? rawConfigRequire.concat(configuredRequire)
+            : rawConfigRequire
+        })
         : info.rawConfig
     },
     action: function (info: ActionTesterOptions) {

--- a/test/mocha/configuration-parser.spec.ts
+++ b/test/mocha/configuration-parser.spec.ts
@@ -48,6 +48,26 @@ describe('mocha configuration-parser', function () {
       mochaRequire: './foo.js'
     })
   })
+  it('supports global requires not in info.configFiles', function () {
+    const rawConfig = [
+      '--bail',
+      '# I am a comment',
+      '--grep foo',
+      '--slow 12',
+      '--timeout 1000',
+      '--retries 42',
+      '--require left-pad'
+    ].join('\n')
+    const parsed = configurationParser(rawConfig, emptyInfo)
+    expect(parsed).to.deep.equal({
+      bail: true,
+      grep: 'foo',
+      retries: '42',
+      slow: '12',
+      timeout: '1000',
+      mochaRequire: 'left-pad'
+    })
+  })
   it('throws when require flags not in info.configFiles', function () {
     const rawConfig = [
       '--bail',


### PR DESCRIPTION
When checking the mocha.opts fix (https://github.com/teambit/bit-envs/pull/53) with the original issue (https://github.com/teambit/bit-envs/issues/48) - I found that there is still an error. This time because it did not properly require the babel transpiler that was `--require`ed in mocha.opts.

In this fix we:
1. adjust the validation method in the opts parser to not throw if the require is external (regardless of whether it appears in the (files)require in bit.json or not).
2. add a test for 1
3. adjust the mocha tester `getDynamicConfig` method to differentiate between local and external mochaRequire options (local: prefixed with `./`, external: not prefixed with `./`) and adjust the configuration accordingly.

I tested this manually with the case in the original bug and it works great.